### PR TITLE
[#8] 테스트 커버리지 측정 자동화 ci 구축

### DIFF
--- a/.github/workflows/ci-with-test-coverage.yml
+++ b/.github/workflows/ci-with-test-coverage.yml
@@ -1,0 +1,49 @@
+name: ci with test coverage
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # pr comment 작성 권한 부여
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build without test
+        run: ./gradlew build -x test
+
+      - name: Runs the unit tests with coverage
+        run: ./gradlew testCoverage
+
+      - name: Create pr comment with jacoco report
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80
+          title: "테스트 커버리지 측정"
+          update-comment: true

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.3'
     id 'io.spring.dependency-management' version '1.1.3'
+    id 'jacoco'
 }
 
 group = 'com.flab'
@@ -9,6 +10,11 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'
+}
+
+jacoco {
+    toolVersion = "0.8.9"
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 configurations {
@@ -34,4 +40,52 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.register('testCoverage', Test) {
+    group 'verification'
+    description 'Runs the unit tests with coverage'
+
+    dependsOn(':test',
+            ':jacocoTestReport',
+            ':jacocoTestCoverageVerification')
+
+    tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+    tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        /*
+        클래스 단위로 브랜치와 라인 커버리지 비율을 체크한다.
+        Lombok으로 생성된 코드는 @Generated를 통해 테스트 커버리지 대상에서 제외된다.
+         */
+        rule {
+            element = 'CLASS'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            excludes = [
+                    'com.flab.tabling.TablingApplication'
+            ]
+        }
+    }
 }


### PR DESCRIPTION
## 작업 사항

* jacoco를 사용해서 테스트 커버리지 측정
* pr 생성 시점에만 수행되도록 자동화 ci 구축
* madrapps/jacoco-report 액션을 사용해서 측정 결과에 대한 pr comment 작성 자동화

## Self-Check

- [ ] 메서드 깊이는 2단계를 유지했습니다.
- [ ] else 키워드를 사용하지 않았습니다.
- [ ] setter/property를 사용하지 않았습니다.
- [ ] 과도하게 줄여쓰지 않았습니다.
