### PR TITLE
[#18] 샘플 데이터 누락 문제 해결, DB 외래키 제약조건 제거

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,10 @@ spring:
     password:
     hikari.jdbc-url: jdbc:h2:mem:~/test;MODE=MYSQL
 
+  jpa:
+    hibernate:
+      ddl-auto: none
+
   h2:
     console:
       enabled: true

--- a/src/main/resources/h2/schema.sql
+++ b/src/main/resources/h2/schema.sql
@@ -1,150 +1,139 @@
-CREATE TABLE `member` (
-    `id` bigint PRIMARY KEY AUTO_INCREMENT,
-    `name` varchar(30) NOT NULL,
-    `email` varchar(255) NOT NULL COMMENT '암호화해서 저장',
-    `password` varchar(255) NOT NULL COMMENT '암호화해서 저장',
-    `role_type` varchar(20) NOT NULL,
-    `created_at` datetime(6) NOT NULL,
+CREATE TABLE `member`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `name`        varchar(30)  NOT NULL,
+    `email`       varchar(255) NOT NULL COMMENT '암호화해서 저장',
+    `password`    varchar(255) NOT NULL COMMENT '암호화해서 저장',
+    `role_type`   varchar(20)  NOT NULL,
+    `created_at`  datetime(6)  NOT NULL,
     `modified_at` datetime(6),
-    `created_by` varchar(50),
+    `created_by`  varchar(50),
     `modified_by` varchar(50)
 );
 
-CREATE TABLE `store` (
-    `id` bigint PRIMARY KEY AUTO_INCREMENT,
-    `member_id` bigint NOT NULL,
-    `category` varchar(20) NOT NULL,
-    `name` varchar(30) NOT NULL,
-    `description` TEXT,
+CREATE TABLE `store`
+(
+    `id`                bigint PRIMARY KEY AUTO_INCREMENT,
+    `member_id`         bigint      NOT NULL,
+    `category`          varchar(20) NOT NULL,
+    `name`              varchar(30) NOT NULL,
+    `description`       TEXT,
     `max_waiting_count` integer COMMENT '대기할 수 있는 최대 사람 수',
-    `created_at` datetime(6),
+    `created_at`        datetime(6),
+    `modified_at`       datetime(6),
+    `created_by`        varchar(50),
+    `modified_by`       varchar(50)
+);
+
+CREATE TABLE `business_hour`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `store_id`    integer,
+    `start_time`  time(6),
+    `end_time`    time(6),
+    `created_at`  datetime(6),
     `modified_at` datetime(6),
-    `created_by` varchar(50),
+    `created_by`  varchar(50),
     `modified_by` varchar(50)
 );
 
-CREATE TABLE `business_hour` (
-     `id` bigint PRIMARY KEY AUTO_INCREMENT,
-     `store_id` integer,
-     `start_time` time(6),
-     `end_time` time(6),
-     `created_at` datetime(6),
-     `modified_at` datetime(6),
-     `created_by` varchar(50),
-     `modified_by` varchar(50)
-);
-
-CREATE TABLE `menu` (
-    `id` bigint PRIMARY KEY AUTO_INCREMENT,
-    `store_id` bigint NOT NULL,
-    `name` varchar(20) NOT NULL COMMENT '메뉴 이름',
+CREATE TABLE `menu`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `store_id`    bigint      NOT NULL,
+    `name`        varchar(20) NOT NULL COMMENT '메뉴 이름',
     `description` TEXT,
-    `price` integer NOT NULL COMMENT '메뉴 가격',
-    `created_at` datetime(6),
+    `price`       integer     NOT NULL COMMENT '메뉴 가격',
+    `created_at`  datetime(6),
     `modified_at` datetime(6),
-    `created_by` varchar(50),
+    `created_by`  varchar(50),
     `modified_by` varchar(50)
 );
 
-CREATE TABLE `favorite` (
-    `id` long PRIMARY KEY,
-    `store_id` long NOT NULL,
-    `member_id` long NOT NULL,
-    `created_at` datetime(6),
+CREATE TABLE `favorite`
+(
+    `id`          long PRIMARY KEY,
+    `store_id`    long NOT NULL,
+    `member_id`   long NOT NULL,
+    `created_at`  datetime(6),
     `modified_at` datetime(6),
-    `created_by` varchar(50),
+    `created_by`  varchar(50),
     `modified_by` varchar(50)
 );
 
-CREATE TABLE `waiting` (
-    `id` bigint PRIMARY KEY,
-    `store_id` bigint NOT NULL,
-    `member_id` bigint NOT NULL,
-    `head_count` integer NOT NULL COMMENT '예약하는 인원 수',
-    `created_at` datetime(6),
+CREATE TABLE `waiting`
+(
+    `id`          bigint PRIMARY KEY,
+    `store_id`    bigint  NOT NULL,
+    `member_id`   bigint  NOT NULL,
+    `head_count`  integer NOT NULL COMMENT '예약하는 인원 수',
+    `created_at`  datetime(6),
     `modified_at` datetime(6),
-    `created_by` varchar(50),
+    `created_by`  varchar(50),
     `modified_by` varchar(50)
 );
 
-CREATE TABLE `notice` (
-    `id` bigint PRIMARY KEY,
-    `member_id` bigint NOT NULL,
-    `title` varchar(50) NOT NULL,
-    `content` text NOT NULL,
-    `is_deleted` tinyint(2) COMMENT '논리적 삭제',
-    `created_at` datetime(6) NOT NULL,
+CREATE TABLE `notice`
+(
+    `id`          bigint PRIMARY KEY,
+    `member_id`   bigint      NOT NULL,
+    `title`       varchar(50) NOT NULL,
+    `content`     text        NOT NULL,
+    `is_deleted`  tinyint(2) COMMENT '논리적 삭제',
+    `created_at`  datetime(6) NOT NULL,
     `modified_at` datetime(6),
-    `created_by` varchar(50),
+    `created_by`  varchar(50),
     `modified_by` varchar(50)
 );
 
-CREATE TABLE `penalty` (
-    `id` bigint PRIMARY KEY,
-    `member_id` bigint NOT NULL,
-    `type` varchar(20),
-    `created_at` datetime(6) NOT NULL,
+CREATE TABLE `penalty`
+(
+    `id`          bigint PRIMARY KEY,
+    `member_id`   bigint      NOT NULL,
+    `type`        varchar(20),
+    `created_at`  datetime(6) NOT NULL,
     `modified_at` datetime(6),
-    `created_by` varchar(50),
+    `created_by`  varchar(50),
     `modified_by` varchar(50)
 );
 
-CREATE TABLE `point` (
-    `id` bigint PRIMARY KEY,
-    `member_id` bigint NOT NULL,
-    `amount` integer NOT NULL,
-    `type` varchar(20) NOT NULL,
-    `created_at` datetime(6) NOT NULL,
+CREATE TABLE `point`
+(
+    `id`          bigint PRIMARY KEY,
+    `member_id`   bigint      NOT NULL,
+    `amount`      integer     NOT NULL,
+    `type`        varchar(20) NOT NULL,
+    `created_at`  datetime(6) NOT NULL,
     `modified_at` datetime(6),
-    `created_by` varchar(50),
+    `created_by`  varchar(50),
     `modified_by` varchar(50)
 );
 
-CREATE TABLE `address` (
-    `id` bigint PRIMARY KEY,
-    `store_id` bigint,
-    `area1` varchar(20) COMMENT '시도',
-    `area2` varchar(20) COMMENT '시군구',
-    `area3` varchar(20) COMMENT '읍면',
-    `land_name` varchar(80) COMMENT '도로명',
+CREATE TABLE `address`
+(
+    `id`           bigint PRIMARY KEY,
+    `store_id`     bigint,
+    `area1`        varchar(20) COMMENT '시도',
+    `area2`        varchar(20) COMMENT '시군구',
+    `area3`        varchar(20) COMMENT '읍면',
+    `land_name`    varchar(80) COMMENT '도로명',
     `land_number1` integer COMMENT '지번본번',
     `land_number2` integer COMMENT '지번부번',
-    `created_at` datetime(6),
-    `modified_at` datetime(6),
-    `created_by` varchar(50),
-    `modified_by` varchar(50)
+    `created_at`   datetime(6),
+    `modified_at`  datetime(6),
+    `created_by`   varchar(50),
+    `modified_by`  varchar(50)
 );
 
-CREATE TABLE `history` (
-    `id` bigint PRIMARY KEY,
-    `table_name` varchar(30),
-    `record_id` bigint,
+CREATE TABLE `history`
+(
+    `id`             bigint PRIMARY KEY,
+    `table_name`     varchar(30),
+    `record_id`      bigint,
     `operation_type` varchar(20) COMMENT '상태값',
-    `snapshot` json,
-    `created_at` datetime(6),
-    `modified_at` datetime(6),
-    `created_by` varchar(50),
-    `modified_by` varchar(50)
+    `snapshot`       json,
+    `created_at`     datetime(6),
+    `modified_at`    datetime(6),
+    `created_by`     varchar(50),
+    `modified_by`    varchar(50)
 );
-
-ALTER TABLE `store` ADD FOREIGN KEY (`member_id`) REFERENCES `member` (`id`);
-
-ALTER TABLE `business_hour` ADD FOREIGN KEY (`store_id`) REFERENCES `store` (`id`);
-
-ALTER TABLE `menu` ADD FOREIGN KEY (`store_id`) REFERENCES `store` (`id`);
-
-ALTER TABLE `address` ADD FOREIGN KEY (`store_id`) REFERENCES `store` (`id`);
-
-ALTER TABLE `waiting` ADD FOREIGN KEY (`member_id`) REFERENCES `member` (`id`);
-
-ALTER TABLE `waiting` ADD FOREIGN KEY (`store_id`) REFERENCES `store` (`id`);
-
-ALTER TABLE `penalty` ADD FOREIGN KEY (`member_id`) REFERENCES `member` (`id`);
-
-ALTER TABLE `point` ADD FOREIGN KEY (`member_id`) REFERENCES `member` (`id`);
-
-ALTER TABLE `favorite` ADD FOREIGN KEY (`store_id`) REFERENCES `store` (`id`);
-
-ALTER TABLE `favorite` ADD FOREIGN KEY (`member_id`) REFERENCES `member` (`id`);
-
-ALTER TABLE `notice` ADD FOREIGN KEY (`member_id`) REFERENCES `member` (`id`);


### PR DESCRIPTION
## 작업 사항

* jpa가 기존 테이블을 삭제하고 자동으로 생성하지 않도록 설정 값 추가
* DB 외래키 제약조건 제거

## Self-Check

- [ ] 메서드 깊이는 2단계를 유지했습니다.
- [ ] else 키워드를 사용하지 않았습니다.
- [ ] setter/property를 사용하지 않았습니다.
- [ ] 과도하게 줄여쓰지 않았습니다.
