### PR TITLE
[#36] Rest Docs 설정 추가

### DIFF
--- a/.github/workflows/ci-with-api-docs.yml
+++ b/.github/workflows/ci-with-api-docs.yml
@@ -22,8 +22,8 @@ jobs:
         run: chmod +x gradlew
       - name : auto configure spring rest docs
         run: |
+          ./gradlew build -x test
           ./gradlew copyDocument
-          cat src/main/resources/static/docs/index.html
       - name : upload pages artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/ci-with-api-docs.yml
+++ b/.github/workflows/ci-with-api-docs.yml
@@ -1,0 +1,43 @@
+name: ci with API rest docs
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # pr comment 작성 권한 부여
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name : auto configure spring rest docs
+        run: |
+          ./gradlew copyDocument
+      - name : upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'src/main/resources/static/docs'
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/ci-with-api-docs.yml
+++ b/.github/workflows/ci-with-api-docs.yml
@@ -23,6 +23,7 @@ jobs:
       - name : auto configure spring rest docs
         run: |
           ./gradlew copyDocument
+          cat src/main/resources/static/docs/index.html
       - name : upload pages artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/ci-with-test-coverage.yml
+++ b/.github/workflows/ci-with-test-coverage.yml
@@ -38,8 +38,6 @@ jobs:
       - name : auto configure spring rest docs
         run: |
           ./gradlew copyDocument
-          if [ -f ./src/main/resources/static/docs ]; then
-          echo "index.html exists"
 
       - name: Runs the unit tests with coverage
         run: ./gradlew testCoverage

--- a/.github/workflows/ci-with-test-coverage.yml
+++ b/.github/workflows/ci-with-test-coverage.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Build without test
         run: ./gradlew build -x test
 
+      - name : auto configure spring rest docs
+        run: |
+          ./gradlew copyDocument
+          if [ -f ./src/main/resources/static/docs ]; then
+          echo "index.html exists"
+
       - name: Runs the unit tests with coverage
         run: ./gradlew testCoverage
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 configurations {
-    asciidoctorExt // asciidoctorExt에 대한 선언
+    asciidoctorExtensions // asciidoctorExt에 대한 선언
 }
 
 group = 'com.flab'
@@ -46,7 +46,7 @@ dependencies {
     // easy-random: 랜덤 테스트 데이터 생성 라이브러리
     testImplementation 'org.jeasy:easy-random-core:5.0.0'
     //rest-docs
-    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
@@ -57,13 +57,14 @@ ext {
 tasks.named('test') {
     outputs.dir snippetsDir // 스니펫이 생성되는 디렉터리를 설정
     useJUnitPlatform()
+    finalizedBy 'asciidoctor'
 }
 
 asciidoctor { // Gradle이 asciidoctor Task를 수행하는 설정 (함수 선언)
-    configurations 'asciidoctorExt' // asciidoctor 확장 설정
+    dependsOn test // Gradle의 test Task 이후 asciidoctor를 수행
+    configurations 'asciidoctorExtensions' // asciidoctor 확장 설정
     baseDirFollowsSourceFile() // .adoc 파일을 include 하면서 사용하기 위한 설정
     inputs.dir snippetsDir // 스니펫을 불러올 위치 설정
-    dependsOn test // Gradle의 test Task 이후 asciidoctor를 수행
 }
 
 asciidoctor.doFirst { // asciidoctor Task가 수행될 때 가장 먼저 수행

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ ext {
 
 tasks.named('test') {
     outputs.dir snippetsDir // 스니펫이 생성되는 디렉터리를 설정
-    useJUnitPlatform()
     finalizedBy 'asciidoctor'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,14 +90,6 @@ task copyDocument(type: Copy) {
     into file("src/main/resources/static/docs")
 }
 
-//build의 bootJar 시 asciidoctor에 의존하여 /static/docs에 index.html이 생성된다.
-bootJar {
-    dependsOn asciidoctor
-    from("${asciidoctor.outputDir}") {
-        into 'static/docs'
-    }
-}
-
 tasks.register('testCoverage', Test) {
     group 'verification'
     description 'Runs the unit tests with coverage'

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ asciidoctor.doFirst {
 
 task copyDocument(type: Copy) { // (12)
     dependsOn asciidoctor
-    from file("build/docs/asciidoc")
+    from file("build/asciidoc/html5/")
     into file("src/main/resources/static/docs")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,20 @@ tasks.named('test') {
     outputs.dir snippetsDir // (6)
 }
 
+task createDirectoryIfNotExists(type: Exec) {
+    def directoryPath = 'build/generated-snippets/'// Replace this with your desired directory path
+    onlyIf {
+        !file(directoryPath).isDirectory()
+    }
+
+    doFirst {
+        println "Creating directory: $directoryPath"
+        mkdir directoryPath
+    }
+}
+
 asciidoctor {
+    dependsOn createDirectoryIfNotExists
     configurations 'asciidoctorExt' // (7)
     baseDirFollowsSourceFile() // (8)
     inputs.dir snippetsDir // (9)

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@ plugins {
     id 'org.springframework.boot' version '3.1.3'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'jacoco'
-    id "org.asciidoctor.jvm.convert" version '3.3.2' // asciidoctor 플러그인 추가
+    id "org.asciidoctor.jvm.convert" version '3.3.2' //rest-docs
 }
 
 configurations {
-    asciidoctorExtensions // asciidoctorExt에 대한 선언
+    asciidoctorExt // rest-docs
 }
 
 group = 'com.flab'
@@ -26,7 +26,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
-    asciidoctorExt // rest-docs
+    asciidoctorExt
 }
 
 repositories {
@@ -46,48 +46,40 @@ dependencies {
     // easy-random: 랜덤 테스트 데이터 생성 라이브러리
     testImplementation 'org.jeasy:easy-random-core:5.0.0'
     //rest-docs
-    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 ext {
-    snippetsDir = file('$buildDir/generated-snippets') // 스니펫이 생성되는 디렉터리 경로를 설정
+    snippetsDir = file('build/generated-snippets') // (5)
 }
 
 tasks.named('test') {
-    systemProperty("org.springframework.restdocs.outputDir", snippetsDir)
-    outputs.dir snippetsDir // 스니펫이 생성되는 디렉터리를 설정
-    finalizedBy 'asciidoctor'
+    useJUnitPlatform()
+    outputs.dir snippetsDir // (6)
 }
 
-asciidoctor { // Gradle이 asciidoctor Task를 수행하는 설정 (함수 선언)
-    dependsOn test // Gradle의 test Task 이후 asciidoctor를 수행
-    configurations 'asciidoctorExtensions' // asciidoctor 확장 설정
-    baseDirFollowsSourceFile() // .adoc 파일을 include 하면서 사용하기 위한 설정
-    inputs.dir snippetsDir // 스니펫을 불러올 위치 설정
+asciidoctor {
+    configurations 'asciidoctorExt' // (7)
+    baseDirFollowsSourceFile() // (8)
+    inputs.dir snippetsDir // (9)
+    dependsOn test // (10)
 }
 
-asciidoctor.doFirst { // asciidoctor Task가 수행될 때 가장 먼저 수행
-    delete file('src/main/resources/static/docs')
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')  // (11)
 }
 
-task copyDocument(type: Copy) { // 생성된 html 파일을 옮긴다
-    dependsOn asciidoctor // Gradle의 asciidoctor Task 이후 수행
-    from file("${asciidoctor.outputDir}")
+task copyDocument(type: Copy) { // (12)
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
     into file("src/main/resources/static/docs")
 }
-
 
 build {
     dependsOn copyDocument
 }
 
-bootJar {
-    dependsOn asciidoctor // asciidoctor 이후 bootJar 수행
-    from ("${asciidoctor.outputDir}") {
-        into 'static/docs'
-    }
-}
 
 tasks.register('testCoverage', Test) {
     group 'verification'

--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,11 @@ dependencies {
 }
 
 ext {
-    snippetsDir = file('build/generated-snippets') // 스니펫이 생성되는 디렉터리 경로를 설정
+    snippetsDir = file('$buildDir/generated-snippets') // 스니펫이 생성되는 디렉터리 경로를 설정
 }
 
 tasks.named('test') {
+    systemProperty("org.springframework.restdocs.outputDir", snippetsDir)
     outputs.dir snippetsDir // 스니펫이 생성되는 디렉터리를 설정
     finalizedBy 'asciidoctor'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ jacoco {
 }
 
 configurations {
+    asciidoctorExtensions
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -41,31 +42,60 @@ dependencies {
     // easy-random: 랜덤 테스트 데이터 생성 라이브러리
     testImplementation 'org.jeasy:easy-random-core:5.0.0'
     //rest-docs
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+}
+tasks.named('test') {
+    useJUnitPlatform()
 }
 
 ext {
-    snippetsDir = file('./build/generated-snippets') // (5)
+    // 아래서 사용할 변수 선언
+    snippetsDir = file('build/generated-snippets')
 }
 
-tasks.named('test') {
+
+test {
+    // 위에서 작성한 snippetsDir 디렉토리를 test의 output으로 구성하는 설정 -> 스니펫 조각들이 build/generated-snippets로 출력
+    outputs.dir snippetsDir
     useJUnitPlatform()
-    outputs.dir snippetsDir // (6)
 }
 
+// asciidoctor 설정
 asciidoctor {
-    inputs.dir snippetsDir // (9)
-    dependsOn test // (10)
+    dependsOn test // test 작업 이후에 작동하도록 하는 설정
+    configurations 'asciidoctorExtensions' // 위에서 작성한 configuration 적용
+    inputs.dir snippetsDir // snippetsDir 를 입력으로 구성
+
+    // source가 없으면 .adoc파일을 전부 html로 만들어버림
+    // source 지정시 특정 adoc만 HTML로 만든다.
+    sources{
+        include("**/index.adoc","**/common/*.adoc")
+    }
+
+    // 특정 .adoc에 다른 adoc 파일을 가져와서(include) 사용하고 싶을 경우 경로를 baseDir로 맞춰주는 설정입니다.
+    // 개별 adoc으로 운영한다면 필요 없는 옵션입니다.
+    baseDirFollowsSourceFile()
 }
 
+// asciidoctor가 실행될 때 static/docs 폴더 비우기
 asciidoctor.doFirst {
-    delete file('src/main/resources/static/docs')  // (11)
+    delete file('src/main/resources/static/docs')
 }
 
-task copyDocument(type: Copy) { // (12)
+// asccidoctor 작업 이후 생성된 HTML 파일을 static/docs 로 copy
+task copyDocument(type: Copy) {
     dependsOn asciidoctor
     from file("build/docs/asciidoc")
     into file("src/main/resources/static/docs")
+}
+
+//build의 bootJar 시 asciidoctor에 의존하여 /static/docs에 index.html이 생성된다.
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }
 
 tasks.register('testCoverage', Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 }
 
 ext {
-    snippetsDir = file('build/generated-snippets') // (5)
+    snippetsDir = file('build/generated-snippets/') // (5)
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -59,20 +59,7 @@ tasks.named('test') {
     outputs.dir snippetsDir // (6)
 }
 
-task createDirectoryIfNotExists(type: Exec) {
-    def directoryPath = 'build/generated-snippets/'// Replace this with your desired directory path
-    onlyIf {
-        !file(directoryPath).isDirectory()
-    }
-
-    doFirst {
-        println "Creating directory: $directoryPath"
-        mkdir directoryPath
-    }
-}
-
 asciidoctor {
-    dependsOn createDirectoryIfNotExists
     configurations 'asciidoctorExt' // (7)
     baseDirFollowsSourceFile() // (8)
     inputs.dir snippetsDir // (9)
@@ -83,9 +70,17 @@ asciidoctor.doFirst {
     delete file('src/main/resources/static/docs')  // (11)
 }
 
+bootJar {
+    dependsOn asciidoctor
+    copy {
+        from "${asciidoctor.outputDir}"
+        into 'BOOT-INF/classes/static/docs'
+    }
+}
+
 task copyDocument(type: Copy) { // (12)
     dependsOn asciidoctor
-    from file("build/asciidoc/html5/")
+    from file("build/docs/asciidoc")
     into file("src/main/resources/static/docs")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,6 @@ plugins {
     id "org.asciidoctor.jvm.convert" version '3.3.2' //rest-docs
 }
 
-configurations {
-    asciidoctorExt // rest-docs
-}
-
 group = 'com.flab'
 version = '0.0.1-SNAPSHOT'
 
@@ -26,7 +22,6 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
-    asciidoctorExt
 }
 
 repositories {
@@ -46,12 +41,11 @@ dependencies {
     // easy-random: 랜덤 테스트 데이터 생성 라이브러리
     testImplementation 'org.jeasy:easy-random-core:5.0.0'
     //rest-docs
-    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 ext {
-    snippetsDir = file('build/generated-snippets/') // (5)
+    snippetsDir = file('./build/generated-snippets') // (5)
 }
 
 tasks.named('test') {
@@ -60,22 +54,12 @@ tasks.named('test') {
 }
 
 asciidoctor {
-    configurations 'asciidoctorExt' // (7)
-    baseDirFollowsSourceFile() // (8)
     inputs.dir snippetsDir // (9)
     dependsOn test // (10)
 }
 
 asciidoctor.doFirst {
     delete file('src/main/resources/static/docs')  // (11)
-}
-
-bootJar {
-    dependsOn asciidoctor
-    copy {
-        from "${asciidoctor.outputDir}"
-        into 'BOOT-INF/classes/static/docs'
-    }
 }
 
 task copyDocument(type: Copy) { // (12)

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id 'org.springframework.boot' version '3.1.3'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'jacoco'
+    id "org.asciidoctor.jvm.convert" version '3.3.2' // asciidoctor 플러그인 추가
+}
+
+configurations {
+    asciidoctorExt // asciidoctorExt에 대한 선언
 }
 
 group = 'com.flab'
@@ -21,6 +26,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt // rest-docs
 }
 
 repositories {
@@ -39,10 +45,47 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     // easy-random: 랜덤 테스트 데이터 생성 라이브러리
     testImplementation 'org.jeasy:easy-random-core:5.0.0'
+    //rest-docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets') // 스니펫이 생성되는 디렉터리 경로를 설정
 }
 
 tasks.named('test') {
+    outputs.dir snippetsDir // 스니펫이 생성되는 디렉터리를 설정
     useJUnitPlatform()
+}
+
+asciidoctor { // Gradle이 asciidoctor Task를 수행하는 설정 (함수 선언)
+    configurations 'asciidoctorExt' // asciidoctor 확장 설정
+    baseDirFollowsSourceFile() // .adoc 파일을 include 하면서 사용하기 위한 설정
+    inputs.dir snippetsDir // 스니펫을 불러올 위치 설정
+    dependsOn test // Gradle의 test Task 이후 asciidoctor를 수행
+}
+
+asciidoctor.doFirst { // asciidoctor Task가 수행될 때 가장 먼저 수행
+    delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) { // 생성된 html 파일을 옮긴다
+    dependsOn asciidoctor // Gradle의 asciidoctor Task 이후 수행
+    from file("${asciidoctor.outputDir}")
+    into file("src/main/resources/static/docs")
+}
+
+
+build {
+    dependsOn copyDocument
+}
+
+bootJar {
+    dependsOn asciidoctor // asciidoctor 이후 bootJar 수행
+    from ("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }
 
 tasks.register('testCoverage', Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -68,11 +68,6 @@ task copyDocument(type: Copy) { // (12)
     into file("src/main/resources/static/docs")
 }
 
-build {
-    dependsOn copyDocument
-}
-
-
 tasks.register('testCoverage', Test) {
     group 'verification'
     description 'Runs the unit tests with coverage'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,8 @@
+= Spring REST Docs Test
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+include::test.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,10 +1,10 @@
 = Spring REST Docs Test
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
 :doctype: book
 :source-highlighter: highlightjs
 :toc: left
 :toclevels: 2
 :seclinks:
-ifndef::snippets[]
-:snippets: ./build/generated-snippets
-endif::[]
 include::test.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -4,5 +4,7 @@
 :toc: left
 :toclevels: 2
 :seclinks:
-
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
 include::test.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,7 +1,7 @@
-= Spring REST Docs Test
 ifndef::snippets[]
-:snippets: ./build/generated-snippets
+:snippets: build/generated-snippets
 endif::[]
+= Tabling API
 :doctype: book
 :source-highlighter: highlightjs
 :toc: left

--- a/src/docs/asciidoc/test.adoc
+++ b/src/docs/asciidoc/test.adoc
@@ -1,3 +1,5 @@
+tabling API 명세서입니다.
+
 == 로그인 성공
 operation::auth-controller-rest-docs-test/login-success[snippets="http-request,http-response"]
 == 로그아웃 성공

--- a/src/docs/asciidoc/test.adoc
+++ b/src/docs/asciidoc/test.adoc
@@ -1,0 +1,16 @@
+== 로그인 성공
+operation::auth-controller-rest-docs-test/login-success[snippets="http-request,http-response"]
+== 로그아웃 성공
+operation::auth-controller-rest-docs-test/logout-success[snippets="http-request,http-response"]
+== 회원가입 성공
+operation::member-controller-rest-docs-test/add-user[snippets="http-request,http-response"]
+== 가게 등록 성공
+operation::store-controller-rest-docs-test/add-store-success[snippets="http-request,http-response"]
+== 가게 삭제 성공
+operation::store-controller-rest-docs-test/delete-store-success[snippets="http-request,http-response"]
+== 가게 정보 변경 성공
+operation::store-controller-rest-docs-test/update-store-success[snippets="http-request,http-response"]
+== 가게 페이지 조회 성공
+operation::store-controller-rest-docs-test/find-store-page-success[snippets="http-request,http-response"]
+== 가게 상세 조회 성공
+operation::store-controller-rest-docs-test/find-store-page-success[snippets="http-request,http-response"]

--- a/src/main/java/com/flab/tabling/TablingApplication.java
+++ b/src/main/java/com/flab/tabling/TablingApplication.java
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
  * 1) @ComponentScan : @Component 어노테이션이 포함된 어노테이션을 스캔하여 빈으로 등록
  * 2) @EnableAutoConfiguration : 사전에 정의한 라이브러리들을 특정 조건이 만족될 경우 빈으로 등록
  */
-@EnableJpaAuditing
 @SpringBootApplication
 public class TablingApplication {
 	public static void main(String[] args) {

--- a/src/main/java/com/flab/tabling/global/config/AuditingConfig.java
+++ b/src/main/java/com/flab/tabling/global/config/AuditingConfig.java
@@ -1,0 +1,9 @@
+package com.flab.tabling.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class AuditingConfig {
+}

--- a/src/test/java/com/flab/tabling/global/config/AbstractRestDocsTest.java
+++ b/src/test/java/com/flab/tabling/global/config/AbstractRestDocsTest.java
@@ -1,0 +1,62 @@
+package com.flab.tabling.global.config;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.tabling.store.web.config.StoreWebConfig;
+import com.flab.tabling.store.web.interceptor.StoreAuthInterceptor;
+
+/**
+ * @Import : Configuration을 두개 이상 사용하는 경우 하나의 설정을 도입하는 어노테이션
+ * @AutoConfigureMockMvc : mockMvc의 auto configuration 가능, 테스트 클래스에서 활용 가능
+ * @MockBean(JpaMetamodelMappingContext.class) : JpaMetamodelMappingContext를 MockBean으로 추가
+ *
+ */
+@Import(RestDocsConfiguration.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+// @MockBean(JpaMetamodelMappingContext.class)
+public abstract class AbstractRestDocsTest {
+	@MockBean
+	private StoreAuthInterceptor storeAuthInterceptor;
+	@MockBean
+	private WebConfig webConfig;
+	@MockBean
+	private StoreWebConfig storeWebConfig;
+	@Autowired
+	protected RestDocumentationResultHandler restDocs;
+	@Autowired
+	protected MockMvc mockMvc;
+	@Autowired
+	protected ObjectMapper objectMapper;
+	@BeforeEach
+	void setUp(
+		final WebApplicationContext context,
+		final RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.apply(documentationConfiguration(restDocumentation))
+			.alwaysDo(MockMvcResultHandlers.print())
+			.alwaysDo(restDocs)
+			.addFilters(new CharacterEncodingFilter("UTF-8", true))
+			.build();
+	}
+
+}

--- a/src/test/java/com/flab/tabling/global/config/RestDocsConfiguration.java
+++ b/src/test/java/com/flab/tabling/global/config/RestDocsConfiguration.java
@@ -1,0 +1,22 @@
+package com.flab.tabling.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+/**
+ * @TestConfiguration : Test를 위한 추가 빈 등록과 사용자 정의 가능
+ */
+@TestConfiguration
+public class RestDocsConfiguration {
+	@Bean
+	public RestDocumentationResultHandler write() {
+		return MockMvcRestDocumentation.document(
+			"{class-name}/{method-name}", // identifier
+			Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+			Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+		);
+	}
+}

--- a/src/test/java/com/flab/tabling/member/controller/AuthControllerRestDocsTest.java
+++ b/src/test/java/com/flab/tabling/member/controller/AuthControllerRestDocsTest.java
@@ -1,0 +1,120 @@
+package com.flab.tabling.member.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import com.flab.tabling.global.config.AbstractRestDocsTest;
+import com.flab.tabling.global.constant.SessionConstant;
+import com.flab.tabling.global.service.StringGenerateFixture;
+import com.flab.tabling.member.dto.MemberAuthDto;
+import com.flab.tabling.member.service.AuthService;
+
+/**
+ * @AutoConfigureMockMvc : WebApplicationContext 주입
+ * @AutoConfigureRestDocs : apply(documentationConfiguration(restDocumentation)) 문서화
+ */
+
+@WebMvcTest(controllers = {AuthController.class})
+class AuthControllerRestDocsTest extends AbstractRestDocsTest {
+	@MockBean
+	AuthService authService;
+	private MockHttpSession session = new MockHttpSession();
+	@DisplayName("로그인 성공 테스트")
+	@Test
+	void loginSuccess() throws Exception {
+		//given
+		String email = StringGenerateFixture.makeEmail(10);
+		String password = StringGenerateFixture.makeByNumbersAndAlphabets(10);
+		MemberAuthDto.Request memberRequestDto = MemberAuthDto.Request
+			.builder()
+			.email(email)
+			.password(password)
+			.build();
+
+		//when
+		MemberAuthDto.Response memberResponseDto = new MemberAuthDto.Response(1L);
+		doReturn(memberResponseDto).when(authService).login(any(), any());
+		MockHttpServletResponse response = mockMvc.perform(post("/login")
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(memberRequestDto)))
+			.andExpect(status().isOk())
+			.andReturn().getResponse();
+		MemberAuthDto.Response result = objectMapper.readValue(response.getContentAsString(),
+			MemberAuthDto.Response.class);
+
+		//then
+		assertThat(result).usingRecursiveComparison().isEqualTo(memberResponseDto);
+	}
+
+	@DisplayName("로그인 : 유효하지 않은 이메일 테스트")
+	@Test
+	void loginFailureByEmail() throws Exception {
+		//given
+		String email = StringGenerateFixture.makeByNumbersAndAlphabets(10);
+		String password = StringGenerateFixture.makeByNumbersAndAlphabets(10);
+		MemberAuthDto.Request memberRequestDto = MemberAuthDto.Request
+			.builder()
+			.email(email)
+			.password(password)
+			.build();
+
+		//when, then
+		mockMvc.perform(post("/login")
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(memberRequestDto)))
+			.andExpect(status().isBadRequest())
+			.andExpect(result -> assertThat(
+				result.getResolvedException() instanceof MethodArgumentNotValidException).isTrue());
+	}
+
+	@DisplayName("로그인 : 유효하지 않은 비밀번호 테스트")
+	@Test
+	void loginFailureByPassword() throws Exception {
+		//given
+		String email = StringGenerateFixture.makeByNumbersAndAlphabets(10);
+		String password = StringGenerateFixture.makeByNumbersAndAlphabets(10);
+		MemberAuthDto.Request memberRequestDto = MemberAuthDto.Request
+			.builder()
+			.email(email)
+			.password(password)
+			.build();
+
+		//when, then
+		mockMvc.perform(post("/login")
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(memberRequestDto)))
+			.andExpect(status().isBadRequest())
+			.andExpect(result -> assertThat(
+				result.getResolvedException() instanceof MethodArgumentNotValidException).isTrue());
+	}
+
+	@DisplayName("로그아웃 : 세션 무효화 테스트")
+	@Test
+	void logoutSuccess() throws Exception {
+		Long memberId = 1L;
+		session.setAttribute(SessionConstant.MEMBER_ID.name(), memberId);
+		MockHttpServletResponse response = mockMvc.perform(delete("/logout")
+				.contentType(MediaType.APPLICATION_JSON)
+				.session(session))
+			.andExpect(status().isOk())
+			.andReturn().getResponse();
+		MemberAuthDto.Response result = objectMapper.readValue(response.getContentAsString(),
+			MemberAuthDto.Response.class);
+		assertThat(result).usingRecursiveComparison().isEqualTo(new MemberAuthDto.Response(1L));
+		Assertions.assertThat(session.isInvalid()).isTrue();
+	}
+}

--- a/src/test/java/com/flab/tabling/member/controller/MemberControllerRestDocsTest.java
+++ b/src/test/java/com/flab/tabling/member/controller/MemberControllerRestDocsTest.java
@@ -1,0 +1,106 @@
+package com.flab.tabling.member.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.flab.tabling.global.config.AbstractRestDocsTest;
+import com.flab.tabling.global.exception.ErrorCode;
+import com.flab.tabling.global.exception.ErrorResponse;
+import com.flab.tabling.global.service.StringGenerateFixture;
+import com.flab.tabling.member.domain.RoleType;
+import com.flab.tabling.member.dto.MemberAddDto;
+import com.flab.tabling.member.service.MemberService;
+
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * @WebMvcTest : 웹 계층과 관련된 빈들만을 찾아서 빈으로 등록 @RestController,  @RestControllerAdvice, WebMvcConfigurer, HandlerMethodArgumentResolver
+ * @MockBean : 가짜 객체인 Mock 객체를 빈으로 등록, main 클래스의 @EnableJpaAuditing JpaMetamodelMappingContext.class 빈 등록
+ * @Autowired : 의존성 주입, 필드 주입, 수정자 주입, 생성자 주입 방식이 있고 생성자가 1개일 경우 생략될 수 있다. 필드 주입은 권장되지 않으나 테스트코드에서는
+ * 필드 주입을 통해서 Jupiter가 스프링 컨테이너에 요청하게 되어서 정상적으로 빈 주입을 받을 수 있게 된다.
+ * @AutoConfigureMockMvc : addFilters = false로 해서 Filter 없이 MockMvc auto-configuration을 설정했다.
+ */
+
+@WebMvcTest(MemberController.class)
+class MemberControllerRestDocsTest extends AbstractRestDocsTest {
+	private final String postURI = "/members";
+
+	@MockBean MemberService memberService;
+	private MockHttpSession session = new MockHttpSession();
+
+
+	@DisplayName("회원가입")
+	@Test
+	void addUser() throws Exception {
+		//given
+		String name = StringGenerateFixture.makeByNumbersAndLowerLetters(8);
+		String password = StringGenerateFixture.makeByNumbersAndAlphabets(10);
+		RoleType roleType = RoleType.CUSTOMER;
+		String email = StringGenerateFixture.makeEmail(8);
+
+		MemberAddDto.Request memberRequestDto = MemberAddDto.Request
+			.builder()
+			.name(name)
+			.password(password)
+			.email(email)
+			.roleType(roleType)
+			.build();
+		MemberAddDto.Response memberResponseDto = new MemberAddDto.Response(1L);
+
+		given(memberService.add(any(MemberAddDto.Request.class), any(HttpSession.class)))
+			.willReturn(memberResponseDto);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			post(postURI)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(memberRequestDto)));
+
+		//then
+		MockHttpServletResponse response = resultActions.andExpect(status().isCreated())
+			.andReturn().getResponse();
+		MemberAddDto.Response memberResponseDtoResult = objectMapper.readValue(response.getContentAsString(),
+			MemberAddDto.Response.class);
+		Assertions.assertThat(memberResponseDtoResult).usingRecursiveComparison().isEqualTo(memberResponseDto);
+	}
+
+	@DisplayName("name 30자 이상 시 예외 발생")
+	@Test
+	void checkInvalidPassword() throws Exception {
+		//given
+		String name = StringGenerateFixture.makeByNumbersAndAlphabets(32);
+		String password = StringGenerateFixture.makeByNumbersAndAlphabets(10);
+		RoleType roleType = RoleType.CUSTOMER;
+		String email = StringGenerateFixture.makeEmail(8);
+
+		MemberAddDto.Request memberRequestDto = MemberAddDto.Request
+			.builder()
+			.name(name)
+			.password(password)
+			.email(email)
+			.roleType(roleType)
+			.build();
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			post(postURI)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(memberRequestDto)));
+		//then
+		MockHttpServletResponse response = resultActions.andExpect(status().isBadRequest())
+			.andReturn().getResponse();
+		ErrorResponse memberResponseDtoResult = objectMapper.readValue(response.getContentAsString(),
+			ErrorResponse.class);
+		Assertions.assertThat(memberResponseDtoResult.getCode()).isEqualTo(ErrorCode.INVALID_PARAMETER);
+	}
+}

--- a/src/test/java/com/flab/tabling/store/web/controller/StoreControllerRestDocsTest.java
+++ b/src/test/java/com/flab/tabling/store/web/controller/StoreControllerRestDocsTest.java
@@ -1,0 +1,151 @@
+package com.flab.tabling.store.web.controller;
+
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.FieldPredicates;
+import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.flab.tabling.global.config.AbstractRestDocsTest;
+import com.flab.tabling.store.dto.StoreAddDto;
+import com.flab.tabling.store.dto.StoreFindDto;
+import com.flab.tabling.store.dto.StoreUpdateDto;
+import com.flab.tabling.store.service.StoreService;
+@WebMvcTest(StoreController.class)
+class StoreControllerRestDocsTest extends AbstractRestDocsTest {
+
+	@MockBean
+	private StoreService storeService;
+
+	private EasyRandom easyRandom = new EasyRandom();
+
+	@Test
+	@DisplayName("식당 등록 요청이 성공하면 등록한 식당에 대한 응답과 상태코드를 반환한다.")
+	void addStoreSuccess() throws Exception {
+		//given
+		EasyRandomParameters conditions = getStoreDtoConditions();
+		EasyRandom easyRandom = new EasyRandom(conditions);
+
+		StoreAddDto.Request requestDto = easyRandom.nextObject(StoreAddDto.Request.class);
+		String requestJson = objectMapper.writeValueAsString(requestDto);
+
+		StoreAddDto.Response responseDto = easyRandom.nextObject(StoreAddDto.Response.class);
+		String responseJson = objectMapper.writeValueAsString(responseDto);
+
+		doReturn(responseDto).when(storeService)
+			.add(any(StoreAddDto.Request.class), eq(1L));
+
+		//expected
+		mockMvc.perform(MockMvcRequestBuilders.post("/stores")
+				.contentType(MediaType.APPLICATION_JSON)
+				.sessionAttr("LOGIN_SESSION", 1L) // TODO: 2023-10-07 로그인 기능 추가 후 세션 이름 교체
+				.content(requestJson)
+			)
+			.andExpect(MockMvcResultMatchers.status().isCreated())
+			.andExpect(MockMvcResultMatchers.content().json(responseJson));
+	}
+
+	@Test
+	@DisplayName("식당 조회 요청이 성공하면 식당 정보와 상태코드를 반환한다.")
+	void findStoreSuccess() throws Exception {
+		//given
+		StoreFindDto.Response responseDto = easyRandom.nextObject(StoreFindDto.Response.class);
+		String responseJson = objectMapper.writeValueAsString(responseDto);
+
+		doReturn(responseDto).when(storeService).find(2L);
+
+		//expected
+		mockMvc.perform(MockMvcRequestBuilders.get("/stores/{id}", 2L)
+				.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(MockMvcResultMatchers.content().json(responseJson));
+	}
+
+	@Test
+	@DisplayName("식당 페이지 조회 요청이 성공하면 페이지와 상태코드를 반환한다.")
+	void findStorePageSuccess() throws Exception {
+		//given
+		List<StoreFindDto.Response> storeFindResponseList = getStoreFindResponseList();
+		Pageable pageable = PageRequest.of(0, 5, Sort.Direction.DESC, "id");
+		PageImpl<StoreFindDto.Response> storeFindResponsePage = new PageImpl<>(storeFindResponseList, pageable, 1);
+		String responseJson = objectMapper.writeValueAsString(storeFindResponsePage);
+
+		doReturn(storeFindResponsePage).when(storeService).findPage(any(Pageable.class));
+
+		//expected
+		mockMvc.perform(MockMvcRequestBuilders.get("/stores")
+				.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(MockMvcResultMatchers.content().json(responseJson));
+	}
+
+	@Test
+	@DisplayName("수정 요청이 성공적으로 수행되면, 상태코드와 함께 응답을 반환한다.")
+	void updateStoreSuccess() throws Exception {
+		//given
+		EasyRandomParameters conditions = getStoreDtoConditions();
+		EasyRandom easyRandom = new EasyRandom(conditions);
+
+		StoreUpdateDto.Request storeUpdateRequest = easyRandom.nextObject(StoreUpdateDto.Request.class);
+		String requestJson = objectMapper.writeValueAsString(storeUpdateRequest);
+
+		StoreUpdateDto.Response storeUpdateResponse = easyRandom.nextObject(StoreUpdateDto.Response.class);
+		String responseJson = objectMapper.writeValueAsString(storeUpdateResponse);
+
+		doReturn(storeUpdateResponse).when(storeService).update(any(StoreUpdateDto.Request.class), eq(1L));
+
+		//when
+		mockMvc.perform(MockMvcRequestBuilders.put("/stores/{id}", 2L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.sessionAttr("LOGIN_SESSION", 1L) // TODO: 2023-10-13 세션 이름 변경 필요
+				.content(requestJson)
+			)
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(MockMvcResultMatchers.content().json(responseJson));
+	}
+
+	@Test
+	@DisplayName("삭제 요청이 성공적으로 수행되면, 상태코드를 반환한다.")
+	void deleteStoreSuccess() throws Exception {
+		//expected
+		mockMvc.perform(MockMvcRequestBuilders.delete("/stores/{id}", 2L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.sessionAttr("LOGIN_SESSION", 1L) // TODO: 2023-10-13 세션 이름 변경 필요
+			)
+			.andExpect(MockMvcResultMatchers.status().isNoContent());
+	}
+
+	private EasyRandomParameters getStoreDtoConditions() {
+		return new EasyRandomParameters()
+			.stringLengthRange(2, 20)
+			.randomize(FieldPredicates.named("id"), () -> 2L)
+			.randomize(FieldPredicates.named("maxWaitingCount"), new IntegerRangeRandomizer(1, 50));
+	}
+
+	private List<StoreFindDto.Response> getStoreFindResponseList() {
+		StoreFindDto.Response storeFindResponseA = easyRandom.nextObject(StoreFindDto.Response.class);
+		StoreFindDto.Response storeFindResponseB = easyRandom.nextObject(StoreFindDto.Response.class);
+
+		List<StoreFindDto.Response> storeFindResponseList = new ArrayList<>();
+		storeFindResponseList.add(storeFindResponseA);
+		storeFindResponseList.add(storeFindResponseB);
+		return storeFindResponseList;
+	}
+}


### PR DESCRIPTION
## 작업 사항
* 컨트롤러 WebMvcTest 추가 
    * WebMvcTest로 하는 경우, Web 관련 설정이나 인터셉터가 추가될 경우, 해당 클래스를 @MockBean 처리해줘야 합니다. 
    * 컨트롤러 테스트를 Rest Docs 적용하기 위해 추가했습니다.
    * 기존 MokitoExtension을 이용한 테스트를 같이 놔둘지 아니면 삭제할지 의논해보면 좋을 것 같습니다.
*  JPA auditing 관련 config 추가
    * ```@WebMvcTest 또는 @DataJPATest```를 원활하게 처리하기 위해서는 config를 추가하는 것이 낫다고 판단하여 추가했습니다.
* restdocs request, response 관련 양식 추가 
* Github Page에 API 명세서를 배포하는 파이프라인 구축
    * https://f-lab-edu.github.io/tabling/

## Self-Check
- [X] 메서드 깊이는 2단계를 유지했습니다.
- [X] else 키워드를 사용하지 않았습니다.
- [X] setter/property를 사용하지 않았습니다.
- [X] 과도하게 줄여쓰지 않았습니다.
