### PR TITLE
[#40] 운영 시간 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     // easy-random: 랜덤 테스트 데이터 생성 라이브러리
     testImplementation 'org.jeasy:easy-random-core:5.0.0'
+    //Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
@@ -95,9 +100,15 @@ jacocoTestCoverageVerification {
                     'com.flab.tabling.global.env.**',
                     'com.flab.tabling.global.constant.**',
                     'com.flab.tabling.global.auth.ExceptionHandlerFilter',
-                    'com.flab.tabling.global.auth.Login*'
+                    'com.flab.tabling.global.auth.Login*',
+                    'com.flab.tabling.**.domain.Q*',
+                    'com.flab.tabling.businesshour.domain.**' // 운영 시간 등록 기능 추가 후 제거
             ]
         }
     }
+}
+
+clean {
+    delete file('src/main/generated')
 }
 

--- a/src/docs/asciidoc/test.adoc
+++ b/src/docs/asciidoc/test.adoc
@@ -1,18 +1,41 @@
 tabling API 명세서입니다.
 
 == 로그인 성공
+
 operation::auth-controller-rest-docs-test/login-success[snippets="http-request,http-response"]
+
 == 로그아웃 성공
+
 operation::auth-controller-rest-docs-test/logout-success[snippets="http-request,http-response"]
+
 == 회원가입 성공
+
 operation::member-controller-rest-docs-test/add-user[snippets="http-request,http-response"]
+
 == 가게 등록 성공
+
 operation::store-controller-rest-docs-test/add-store-success[snippets="http-request,http-response"]
+
 == 가게 삭제 성공
+
 operation::store-controller-rest-docs-test/delete-store-success[snippets="http-request,http-response"]
+
 == 가게 정보 변경 성공
+
 operation::store-controller-rest-docs-test/update-store-success[snippets="http-request,http-response"]
+
+== 가게 단건 조회 성공
+
+operation::store-controller-rest-docs-test/find-store-success[snippets="http-request,http-response"]
+
 == 가게 페이지 조회 성공
+
 operation::store-controller-rest-docs-test/find-store-page-success[snippets="http-request,http-response"]
-== 가게 상세 조회 성공
-operation::store-controller-rest-docs-test/find-store-page-success[snippets="http-request,http-response"]
+
+== 운영 시간 단건 조회 성공
+
+operation::business-hour-controller-rest-docs-test/success-find[snippets="http-request,http-response"]
+
+== 운영 시간 페이지 조회 성공
+
+operation::business-hour-controller-rest-docs-test/success-find-page[snippets="http-request,http-response"]

--- a/src/main/java/com/flab/tabling/businesshour/BusinessHourQueryService.java
+++ b/src/main/java/com/flab/tabling/businesshour/BusinessHourQueryService.java
@@ -1,0 +1,7 @@
+package com.flab.tabling.businesshour;
+
+import java.time.LocalDateTime;
+
+public interface BusinessHourQueryService {
+	public Boolean isBusinessHour(Long storeId, LocalDateTime requestTime);
+}

--- a/src/main/java/com/flab/tabling/businesshour/controller/BusinessHourController.java
+++ b/src/main/java/com/flab/tabling/businesshour/controller/BusinessHourController.java
@@ -1,0 +1,37 @@
+package com.flab.tabling.businesshour.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flab.tabling.businesshour.dto.BusinessHourFindDto;
+import com.flab.tabling.businesshour.service.BusinessHourQueryService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class BusinessHourController {
+
+	public final BusinessHourQueryService businessHourQueryService;
+
+	@GetMapping("/business-hours/{id}")
+	public ResponseEntity<BusinessHourFindDto.Response> find(@PathVariable Long id) {
+		BusinessHourFindDto.Response businessHourFindResponse = businessHourQueryService.findBusinessHour(id);
+		return ResponseEntity.status(HttpStatus.OK).body(businessHourFindResponse);
+	}
+
+	@GetMapping("/business-hours")
+	public ResponseEntity<Page<BusinessHourFindDto.Response>> findPage(
+		@ModelAttribute BusinessHourFindDto.Request businessHourFindRequest, @PageableDefault Pageable pageable) {
+		Page<BusinessHourFindDto.Response> businessHourFindResonsePage = businessHourQueryService.findBusinessHours(
+			businessHourFindRequest, pageable);
+		return ResponseEntity.status(HttpStatus.OK).body(businessHourFindResonsePage);
+	}
+}

--- a/src/main/java/com/flab/tabling/businesshour/domain/BusinessHour.java
+++ b/src/main/java/com/flab/tabling/businesshour/domain/BusinessHour.java
@@ -1,0 +1,48 @@
+package com.flab.tabling.businesshour.domain;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+import com.flab.tabling.store.domain.Store;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BusinessHour {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
+	@Enumerated(value = EnumType.STRING)
+	private DayOfWeek dayOfWeek;
+	private LocalTime startTime;
+	private LocalTime endTime;
+
+	@Builder
+	public BusinessHour(Store store, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+		this.store = store;
+		this.dayOfWeek = dayOfWeek;
+		this.startTime = startTime;
+		this.endTime = endTime;
+	}
+
+	public boolean isBusinessHour(LocalTime requestTime) {
+		return !requestTime.isBefore(startTime) && !requestTime.isAfter(endTime);
+	}
+}

--- a/src/main/java/com/flab/tabling/businesshour/dto/BusinessHourFindDto.java
+++ b/src/main/java/com/flab/tabling/businesshour/dto/BusinessHourFindDto.java
@@ -1,0 +1,40 @@
+package com.flab.tabling.businesshour.dto;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+import com.flab.tabling.businesshour.domain.BusinessHour;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BusinessHourFindDto {
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class Request {
+		private Long storeId;
+		private DayOfWeek dayOfWeek;
+
+		public Request(Long storeId, DayOfWeek dayOfWeek) {
+			this.storeId = storeId;
+			this.dayOfWeek = dayOfWeek;
+		}
+	}
+
+	@Getter
+	public static class Response {
+		private Long storeId;
+		private DayOfWeek dayOfWeek;
+		private LocalTime startTime;
+		private LocalTime endTime;
+
+		public Response(BusinessHour businessHour) {
+			this.storeId = businessHour.getStore().getId();
+			this.dayOfWeek = businessHour.getDayOfWeek();
+			this.startTime = businessHour.getStartTime();
+			this.endTime = businessHour.getEndTime();
+		}
+	}
+}

--- a/src/main/java/com/flab/tabling/businesshour/exception/BusinessHourNotFoundException.java
+++ b/src/main/java/com/flab/tabling/businesshour/exception/BusinessHourNotFoundException.java
@@ -1,0 +1,10 @@
+package com.flab.tabling.businesshour.exception;
+
+import com.flab.tabling.global.exception.BusinessException;
+import com.flab.tabling.global.exception.ErrorCode;
+
+public class BusinessHourNotFoundException extends BusinessException {
+	public BusinessHourNotFoundException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+}

--- a/src/main/java/com/flab/tabling/businesshour/repository/BusinessHourDynamicQueryRepository.java
+++ b/src/main/java/com/flab/tabling/businesshour/repository/BusinessHourDynamicQueryRepository.java
@@ -1,0 +1,48 @@
+package com.flab.tabling.businesshour.repository;
+
+import static com.flab.tabling.businesshour.domain.QBusinessHour.*;
+
+import java.time.DayOfWeek;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.flab.tabling.businesshour.domain.BusinessHour;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Repository
+public class BusinessHourDynamicQueryRepository {
+	private final JPAQueryFactory queryFactory;
+
+	public BusinessHourDynamicQueryRepository(EntityManager entityManager) {
+		this.queryFactory = new JPAQueryFactory(entityManager);
+	}
+
+	public Page<BusinessHour> findBusinessHours(Long storeId, DayOfWeek dayOfWeek, Pageable pageable) {
+		QueryResults<BusinessHour> queriedResults = queryFactory.selectFrom(businessHour)
+			.where(storeIdEq(storeId), dayOfWeekEq(dayOfWeek))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(businessHour.dayOfWeek.asc())
+			.fetchResults();
+
+		List<BusinessHour> businessHourList = queriedResults.getResults();
+		long totalCount = queriedResults.getTotal();
+		return new PageImpl<>(businessHourList, pageable, totalCount);
+	}
+
+	private BooleanExpression storeIdEq(Long storeId) {
+		return storeId != null ? businessHour.store.id.eq(storeId) : null;
+	}
+
+	private BooleanExpression dayOfWeekEq(DayOfWeek dayOfWeek) {
+		return dayOfWeek != null ? businessHour.dayOfWeek.eq(dayOfWeek) : null;
+	}
+}

--- a/src/main/java/com/flab/tabling/businesshour/repository/BusinessHourRepository.java
+++ b/src/main/java/com/flab/tabling/businesshour/repository/BusinessHourRepository.java
@@ -1,0 +1,15 @@
+package com.flab.tabling.businesshour.repository;
+
+import java.time.DayOfWeek;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.flab.tabling.businesshour.domain.BusinessHour;
+
+public interface BusinessHourRepository extends JpaRepository<BusinessHour, Long> {
+
+	@Query("select b from BusinessHour b where b.store.id = :storeId and b.dayOfWeek = :dayOfWeek")
+	List<BusinessHour> findBusinessHours(Long storeId, DayOfWeek dayOfWeek);
+}

--- a/src/main/java/com/flab/tabling/businesshour/service/BusinessHourQueryService.java
+++ b/src/main/java/com/flab/tabling/businesshour/service/BusinessHourQueryService.java
@@ -3,5 +3,5 @@ package com.flab.tabling.businesshour.service;
 import java.time.LocalDateTime;
 
 public interface BusinessHourQueryService {
-	public Boolean isBusinessHour(Long storeId, LocalDateTime requestTime);
+	boolean isBusinessHour(Long storeId, LocalDateTime requestTime);
 }

--- a/src/main/java/com/flab/tabling/businesshour/service/BusinessHourQueryService.java
+++ b/src/main/java/com/flab/tabling/businesshour/service/BusinessHourQueryService.java
@@ -2,6 +2,16 @@ package com.flab.tabling.businesshour.service;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.flab.tabling.businesshour.dto.BusinessHourFindDto;
+
 public interface BusinessHourQueryService {
+	BusinessHourFindDto.Response findBusinessHour(Long id);
+
+	Page<BusinessHourFindDto.Response> findBusinessHours(BusinessHourFindDto.Request businessHourFindRequest,
+		Pageable pageable);
+
 	boolean isBusinessHour(Long storeId, LocalDateTime requestTime);
 }

--- a/src/main/java/com/flab/tabling/businesshour/service/BusinessHourQueryService.java
+++ b/src/main/java/com/flab/tabling/businesshour/service/BusinessHourQueryService.java
@@ -1,4 +1,4 @@
-package com.flab.tabling.businesshour;
+package com.flab.tabling.businesshour.service;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/flab/tabling/businesshour/service/BusinessHourQueryServiceImpl.java
+++ b/src/main/java/com/flab/tabling/businesshour/service/BusinessHourQueryServiceImpl.java
@@ -1,0 +1,54 @@
+package com.flab.tabling.businesshour.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.flab.tabling.businesshour.domain.BusinessHour;
+import com.flab.tabling.businesshour.dto.BusinessHourFindDto;
+import com.flab.tabling.businesshour.exception.BusinessHourNotFoundException;
+import com.flab.tabling.businesshour.repository.BusinessHourDynamicQueryRepository;
+import com.flab.tabling.businesshour.repository.BusinessHourRepository;
+import com.flab.tabling.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BusinessHourQueryServiceImpl implements BusinessHourQueryService {
+
+	private final BusinessHourRepository businessHourRepository;
+	private final BusinessHourDynamicQueryRepository businessHourDynamicQueryRepository;
+
+	@Override
+	public BusinessHourFindDto.Response findBusinessHour(Long id) {
+		BusinessHour queriedBusinessHour = businessHourRepository.findById(id)
+			.orElseThrow(() -> new BusinessHourNotFoundException(ErrorCode.BUSINESS_HOUR_NOT_FOUND,
+				"business hour with this id is not found"));
+		return new BusinessHourFindDto.Response(queriedBusinessHour);
+	}
+
+	@Override
+	public Page<BusinessHourFindDto.Response> findBusinessHours(BusinessHourFindDto.Request businessHourFindRequest,
+		Pageable pageable) {
+		return businessHourDynamicQueryRepository.findBusinessHours(businessHourFindRequest.getStoreId(),
+			businessHourFindRequest.getDayOfWeek(), pageable).map(BusinessHourFindDto.Response::new);
+	}
+
+	@Override
+	public boolean isBusinessHour(Long storeId, LocalDateTime requestDateTime) {
+		DayOfWeek requestDayOfWeek = requestDateTime.getDayOfWeek();
+		LocalTime requestTime = requestDateTime.toLocalTime();
+		List<BusinessHour> targetBusinessHours = businessHourRepository.findBusinessHours(storeId, requestDayOfWeek);
+		return checkBusinessHour(targetBusinessHours, requestTime);
+	}
+
+	private boolean checkBusinessHour(List<BusinessHour> targetBusinessHours, LocalTime requestTime) {
+		return targetBusinessHours.stream().anyMatch(businessHour -> businessHour.isBusinessHour(requestTime));
+	}
+}

--- a/src/main/java/com/flab/tabling/global/exception/ErrorCode.java
+++ b/src/main/java/com/flab/tabling/global/exception/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
 	MEMBER_DUPLICATED("member already exists", 400),
 	MEMBER_NOT_FOUND("member not found", 404),
 	STORE_NOT_FOUND("store not found", 404),
+	BUSINESS_HOUR_NOT_FOUND("business hour not found", 404),
 	INVALID_SESSION("session is invalid", 400),
 	INVALID_PARAMETER("parameter is invalid", 400),
 	AUTHENTICATION_FAILED("authentication failed", 401),

--- a/src/main/resources/h2/data.sql
+++ b/src/main/resources/h2/data.sql
@@ -74,24 +74,28 @@ VALUES (3, 2, 'WESTERN_FOOD', '식당C', 'xx해변에 위치한 레스토랑 입
 -- 영업 시간
 INSERT
 INTO business_hour
-(id, store_id, start_time, end_time, created_at, modified_at, created_by, modified_by)
-VALUES (1, 1, '08:00:00', '21:00:00', '2023-09-18', null, null, null);
+(id, store_id, day_of_week, start_time, end_time, created_at, modified_at, created_by, modified_by)
+VALUES (1, 1, 'MONDAY', '08:00:00', '21:00:00', '2023-09-18', null, null, null);
 INSERT
 INTO business_hour
-(id, store_id, start_time, end_time, created_at, modified_at, created_by, modified_by)
-VALUES (2, 2, '09:00:00', '15:00:00', '2023-09-19', null, null, null);
+(id, store_id, day_of_week, start_time, end_time, created_at, modified_at, created_by, modified_by)
+VALUES (2, 2, 'TUESDAY', '09:00:00', '15:00:00', '2023-09-19', null, null, null);
 INSERT
 INTO business_hour
-(id, store_id, start_time, end_time, created_at, modified_at, created_by, modified_by)
-VALUES (3, 2, '18:00:00', '01:00:00', '2023-09-19', null, null, null);
+(id, store_id, day_of_week, start_time, end_time, created_at, modified_at, created_by, modified_by)
+VALUES (3, 2, 'TUESDAY', '18:00:00', '23:59:59.999999', '2023-09-19', null, null, null);
 INSERT
 INTO business_hour
-(id, store_id, start_time, end_time, created_at, modified_at, created_by, modified_by)
-VALUES (4, 3, '11:00:00', '16:00:00', '2023-09-19', null, null, null);
+(id, store_id, day_of_week, start_time, end_time, created_at, modified_at, created_by, modified_by)
+VALUES (4, 2, 'WEDNESDAY', '00:00:00', '01:00:00', '2023-09-19', null, null, null);
 INSERT
 INTO business_hour
-(id, store_id, start_time, end_time, created_at, modified_at, created_by, modified_by)
-VALUES (5, 3, '18:00:00', '23:00:00', '2023-09-19', null, null, null);
+(id, store_id, day_of_week, start_time, end_time, created_at, modified_at, created_by, modified_by)
+VALUES (5, 3, 'TUESDAY', '11:00:00', '16:00:00', '2023-09-19', null, null, null);
+INSERT
+INTO business_hour
+(id, store_id, day_of_week, start_time, end_time, created_at, modified_at, created_by, modified_by)
+VALUES (6, 3, 'TUESDAY', '18:00:00', '23:00:00', '2023-09-19', null, null, null);
 
 -- 메뉴
 INSERT

--- a/src/main/resources/h2/schema.sql
+++ b/src/main/resources/h2/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE `business_hour`
 (
     `id`          bigint PRIMARY KEY AUTO_INCREMENT,
     `store_id`    integer,
+    `day_of_week` varchar(10),
     `start_time`  time(6),
     `end_time`    time(6),
     `created_at`  datetime(6),
@@ -79,7 +80,7 @@ CREATE TABLE `notice`
     `member_id`   bigint      NOT NULL,
     `title`       varchar(50) NOT NULL,
     `content`     text        NOT NULL,
-    `is_deleted`  tinyint(2) COMMENT '논리적 삭제',
+    `is_deleted`  tinyint COMMENT '논리적 삭제',
     `created_at`  datetime(6) NOT NULL,
     `modified_at` datetime(6),
     `created_by`  varchar(50),

--- a/src/test/java/com/flab/tabling/FixtureFactory.java
+++ b/src/test/java/com/flab/tabling/FixtureFactory.java
@@ -1,0 +1,17 @@
+package com.flab.tabling;
+
+import com.flab.tabling.businesshour.BusinessHourFixture;
+import com.flab.tabling.store.StoreFixture;
+
+public class FixtureFactory {
+	private static final StoreFixture storeFixture = new StoreFixture();
+	private static final BusinessHourFixture businessHourFixture = new BusinessHourFixture();
+
+	public static StoreFixture storeFixture() {
+		return storeFixture;
+	}
+
+	public static BusinessHourFixture businessHourFixture() {
+		return businessHourFixture;
+	}
+}

--- a/src/test/java/com/flab/tabling/businesshour/BusinessHourFixture.java
+++ b/src/test/java/com/flab/tabling/businesshour/BusinessHourFixture.java
@@ -1,0 +1,84 @@
+package com.flab.tabling.businesshour;
+
+import static org.jeasy.random.FieldPredicates.*;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import com.flab.tabling.FixtureFactory;
+import com.flab.tabling.businesshour.domain.BusinessHour;
+import com.flab.tabling.store.StoreFixture;
+import com.flab.tabling.store.domain.Store;
+
+public class BusinessHourFixture {
+
+	private static final Long ID = 3L;
+	private static final int YEAR = 2023;
+	private static final int MONTH = 9;
+	private static final int DAY_OF_MONTH = 19;
+	private static final int START_TIME = 9;
+	private static final int END_TIME = 15;
+	private static final int MINUTE = 0;
+
+	private StoreFixture storeFixture = FixtureFactory.storeFixture();
+
+	public BusinessHour getBusinessHour(Long id, Long storeId) {
+		Store targetStore = storeFixture.getStore(storeId);
+		EasyRandomParameters parameters = getCustomParameters(id, targetStore, getDayOfWeek(), START_TIME, END_TIME);
+		EasyRandom businessHourRandom = new EasyRandom(parameters);
+		return businessHourRandom.nextObject(BusinessHour.class);
+	}
+
+	public BusinessHour getBusinessHour(Long storeId, int startTime, int endTime) {
+		Store targetStore = storeFixture.getStore(storeId);
+		EasyRandomParameters parameters = getCustomParameters(ID, targetStore, getDayOfWeek(), startTime, endTime);
+		EasyRandom businessHourRandom = new EasyRandom(parameters);
+		return businessHourRandom.nextObject(BusinessHour.class);
+	}
+
+	public List<BusinessHour> getBusinessHoursWithOneStore(Long storeId, int startTime, int breakStartTime,
+		int breakEndTime,
+		int endTime) {
+		List<BusinessHour> businessHours = new ArrayList<>();
+		businessHours.add(getBusinessHour(storeId, startTime, breakStartTime));
+		businessHours.add(getBusinessHour(storeId, breakEndTime, endTime));
+		return businessHours;
+	}
+
+	public Page<BusinessHour> getBusinessHourPageWithOneStore(Long storeId) {
+		List<BusinessHour> targetBusinessHours = getBusinessHoursWithOneStore(storeId, 8, 15, 18, 22);
+		return new PageImpl<>(targetBusinessHours, PageRequest.of(0, 10), 1);
+	}
+
+	public LocalDateTime getLocalDateTime(int targetTime) {
+		return LocalDateTime.of(YEAR, MONTH, DAY_OF_MONTH, targetTime, MINUTE);
+	}
+
+	public LocalTime getLocalTime(int targetTime) {
+		return LocalTime.of(targetTime, MINUTE);
+	}
+
+	public DayOfWeek getDayOfWeek() {
+		return LocalDate.of(YEAR, MONTH, DAY_OF_MONTH).getDayOfWeek();
+	}
+
+	private EasyRandomParameters getCustomParameters(Long id, Store targetStore, DayOfWeek dayOfWeek, int startTime,
+		int endTime) {
+		return new EasyRandomParameters()
+			.randomize(named("id"), () -> id)
+			.randomize(named("store"), () -> targetStore)
+			.randomize(named("dayOfWeek"), () -> dayOfWeek)
+			.randomize(named("startTime"), () -> getLocalTime(startTime))
+			.randomize(named("endTime"), () -> getLocalTime(endTime));
+	}
+}

--- a/src/test/java/com/flab/tabling/businesshour/controller/BusinessHourControllerRestDocsTest.java
+++ b/src/test/java/com/flab/tabling/businesshour/controller/BusinessHourControllerRestDocsTest.java
@@ -1,0 +1,78 @@
+package com.flab.tabling.businesshour.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.flab.tabling.FixtureFactory;
+import com.flab.tabling.businesshour.BusinessHourFixture;
+import com.flab.tabling.businesshour.domain.BusinessHour;
+import com.flab.tabling.businesshour.dto.BusinessHourFindDto;
+import com.flab.tabling.businesshour.service.BusinessHourQueryServiceImpl;
+import com.flab.tabling.global.config.AbstractRestDocsTest;
+
+@WebMvcTest(BusinessHourController.class)
+class BusinessHourControllerRestDocsTest extends AbstractRestDocsTest {
+	@MockBean
+	private BusinessHourQueryServiceImpl businessHourQueryService;
+	private BusinessHourFixture businessHourFixture = FixtureFactory.businessHourFixture();
+
+	@Test
+	@DisplayName("운영 시간 단건 조회에 성공하면 상태코드와 응답을 반환한다.")
+	void successFind() throws Exception {
+		//given
+		BusinessHourFindDto.Response businessHourFindResponse = getBusinessHourFindResponse(3L);
+		String responseJson = objectMapper.registerModule(new JavaTimeModule())
+			.writeValueAsString(businessHourFindResponse);
+
+		doReturn(businessHourFindResponse).when(businessHourQueryService).findBusinessHour(3L);
+
+		//expected
+		mockMvc.perform(get("/business-hours/{id}", 3L)
+				.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isOk())
+			.andExpect(content().json(responseJson));
+	}
+
+	@Test
+	@DisplayName("운영 시간 페이지 조회에 성공하면 상태코드와 응답을 반환한다.")
+	void successFindPage() throws Exception {
+		//given
+		Page<BusinessHourFindDto.Response> businessHourFindResponsePage = getBusinessHourFindResponsePage();
+		String responseJson = objectMapper.registerModule(new JavaTimeModule())
+			.writeValueAsString(businessHourFindResponsePage);
+
+		doReturn(businessHourFindResponsePage).when(businessHourQueryService)
+			.findBusinessHours(any(BusinessHourFindDto.Request.class), any(Pageable.class));
+
+		//expected
+		mockMvc.perform(get("/business-hours")
+				.contentType(MediaType.APPLICATION_JSON)
+				.queryParam("storeId", "2")
+				.queryParam("dayOfWeek", "TUESDAY")
+			).andExpect(status().isOk())
+			.andExpect(content().json(responseJson));
+	}
+
+	private BusinessHourFindDto.Response getBusinessHourFindResponse(Long id) {
+		return new BusinessHourFindDto.Response(businessHourFixture.getBusinessHour(id, 2L));
+	}
+
+	private Page<BusinessHourFindDto.Response> getBusinessHourFindResponsePage() {
+		List<BusinessHour> businessHourList = businessHourFixture.getBusinessHoursWithOneStore(2L, 8, 15, 18, 22);
+		return new PageImpl<>(businessHourList, PageRequest.of(0, 10), 1).map(BusinessHourFindDto.Response::new);
+	}
+}

--- a/src/test/java/com/flab/tabling/businesshour/controller/BusinessHourControllerTest.java
+++ b/src/test/java/com/flab/tabling/businesshour/controller/BusinessHourControllerTest.java
@@ -1,0 +1,96 @@
+package com.flab.tabling.businesshour.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.flab.tabling.FixtureFactory;
+import com.flab.tabling.businesshour.BusinessHourFixture;
+import com.flab.tabling.businesshour.domain.BusinessHour;
+import com.flab.tabling.businesshour.dto.BusinessHourFindDto;
+import com.flab.tabling.businesshour.service.BusinessHourQueryServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class BusinessHourControllerTest {
+	@InjectMocks
+	private BusinessHourController businessHourController;
+	@Mock
+	private BusinessHourQueryServiceImpl businessHourQueryService;
+	private MockMvc mockMvc;
+	private ObjectMapper objectMapper;
+	private BusinessHourFixture businessHourFixture = FixtureFactory.businessHourFixture();
+
+	@BeforeEach
+	public void init() {
+		mockMvc = MockMvcBuilders.standaloneSetup(businessHourController)
+			.setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+			.build();
+		objectMapper = new ObjectMapper();
+	}
+
+	@Test
+	@DisplayName("운영 시간 단건 조회에 성공하면 상태코드와 응답을 반환한다.")
+	void successFind() throws Exception {
+		//given
+		BusinessHourFindDto.Response businessHourFindResponse = getBusinessHourFindResponse(3L);
+		String responseJson = objectMapper.registerModule(new JavaTimeModule())
+			.writeValueAsString(businessHourFindResponse);
+
+		doReturn(businessHourFindResponse).when(businessHourQueryService).findBusinessHour(3L);
+
+		//expected
+		mockMvc.perform(get("/business-hours/{id}", 3L)
+				.contentType(MediaType.APPLICATION_JSON)
+			).andExpect(status().isOk())
+			.andExpect(content().json(responseJson));
+	}
+
+	@Test
+	@DisplayName("운영 시간 페이지 조회에 성공하면 상태코드와 응답을 반환한다.")
+	void successFindPage() throws Exception {
+		//given
+		Page<BusinessHourFindDto.Response> businessHourFindResponsePage = getBusinessHourFindResponsePage();
+		String responseJson = objectMapper.registerModule(new JavaTimeModule())
+			.writeValueAsString(businessHourFindResponsePage);
+
+		doReturn(businessHourFindResponsePage).when(businessHourQueryService)
+			.findBusinessHours(any(BusinessHourFindDto.Request.class), any(Pageable.class));
+
+		//expected
+		mockMvc.perform(get("/business-hours")
+				.contentType(MediaType.APPLICATION_JSON)
+				.queryParam("storeId", "2")
+				.queryParam("dayOfWeek", "TUESDAY")
+			).andExpect(status().isOk())
+			.andExpect(content().json(responseJson));
+	}
+
+	private BusinessHourFindDto.Response getBusinessHourFindResponse(Long id) {
+		return new BusinessHourFindDto.Response(businessHourFixture.getBusinessHour(id, 2L));
+	}
+
+	private Page<BusinessHourFindDto.Response> getBusinessHourFindResponsePage() {
+		List<BusinessHour> businessHourList = businessHourFixture.getBusinessHoursWithOneStore(2L, 8, 15, 18, 22);
+		return new PageImpl<>(businessHourList, PageRequest.of(0, 10), 1).map(BusinessHourFindDto.Response::new);
+	}
+}

--- a/src/test/java/com/flab/tabling/businesshour/domain/BusinessHourTest.java
+++ b/src/test/java/com/flab/tabling/businesshour/domain/BusinessHourTest.java
@@ -1,0 +1,60 @@
+package com.flab.tabling.businesshour.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flab.tabling.FixtureFactory;
+import com.flab.tabling.businesshour.BusinessHourFixture;
+
+@ExtendWith(MockitoExtension.class)
+class BusinessHourTest {
+	private BusinessHourFixture businessHourFixture = FixtureFactory.businessHourFixture();
+
+	@Test
+	@DisplayName("요청 시간이 운영 시간이라면 true를 반환한다.")
+	void successWithCorrectBusinessHour() {
+		//given
+		BusinessHour businessHour = businessHourFixture.getBusinessHour(2L, 8, 22);
+		LocalTime requestTime = businessHourFixture.getLocalTime(9);
+
+		//when
+		boolean result = businessHour.isBusinessHour(requestTime);
+
+		//then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("요청 시간이 운영 시간 이전이라면 false를 반환한다.")
+	void failWithBeforeBusinessHour() {
+		//given
+		BusinessHour businessHour = businessHourFixture.getBusinessHour(2L, 8, 22);
+		LocalTime requestTime = businessHourFixture.getLocalTime(5);
+
+		//when
+		boolean result = businessHour.isBusinessHour(requestTime);
+
+		//then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("요청 시간이 운영 시간 이후라면 false를 반환한다.")
+	void failWithAfterBusinessHour() {
+		//given
+		BusinessHour businessHour = businessHourFixture.getBusinessHour(2L, 8, 22);
+		LocalTime requestTime = businessHourFixture.getLocalTime(23);
+
+		//when
+		boolean result = businessHour.isBusinessHour(requestTime);
+
+		//then
+		assertThat(result).isFalse();
+	}
+}

--- a/src/test/java/com/flab/tabling/businesshour/repository/BusinessHourDynamicQueryRepositoryTest.java
+++ b/src/test/java/com/flab/tabling/businesshour/repository/BusinessHourDynamicQueryRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.flab.tabling.businesshour.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.DayOfWeek;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.flab.tabling.FixtureFactory;
+import com.flab.tabling.businesshour.BusinessHourFixture;
+import com.flab.tabling.businesshour.domain.BusinessHour;
+
+import jakarta.persistence.EntityManager;
+
+@DataJpaTest
+class BusinessHourDynamicQueryRepositoryTest {
+	@Autowired
+	EntityManager entityManager;
+	BusinessHourDynamicQueryRepository dynamicQueryRepository;
+	BusinessHourFixture businessHourFixture = FixtureFactory.businessHourFixture();
+
+	@BeforeEach
+	public void init() {
+		dynamicQueryRepository = new BusinessHourDynamicQueryRepository(entityManager);
+	}
+
+	@Test
+	@DisplayName("식당, 요일 조건을 모두 충족하는 운영 시간 조회에 성공한다.")
+	void findSuccessWithAllConditions() {
+		//given
+		DayOfWeek requestDayOfWeek = businessHourFixture.getDayOfWeek();
+		Pageable pageable = PageRequest.of(0, 10);
+
+		//when
+		Page<BusinessHour> businessHours = dynamicQueryRepository.findBusinessHours(2L, requestDayOfWeek, pageable);
+
+		//then
+		assertThat(businessHours.getContent().size()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("식당 조건만 충족하는 운영 시간 조회에 성공한다.")
+	void findSuccessWithOnlyStore() {
+		//given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		//when
+		Page<BusinessHour> businessHours = dynamicQueryRepository.findBusinessHours(3L, null, pageable);
+
+		//then
+		assertThat(businessHours.getContent().size()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("요일 조건만 충족하는 운영 시간 조회에 성공한다.")
+	void findSuccessWithOnlyDayOfWeek() {
+		//given
+		DayOfWeek requestDayOfWeek = businessHourFixture.getDayOfWeek();
+		Pageable pageable = PageRequest.of(0, 10);
+
+		//when
+		Page<BusinessHour> businessHours = dynamicQueryRepository.findBusinessHours(null, requestDayOfWeek, pageable);
+
+		//then
+		assertThat(businessHours.getContent().size()).isEqualTo(4);
+	}
+
+	@Test
+	@DisplayName("조건이 없다면, 모든 운영 시간을 조회한다.")
+	void findSuccessWithNoCondition() {
+		//given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		//when
+		Page<BusinessHour> businessHours = dynamicQueryRepository.findBusinessHours(null, null, pageable);
+
+		//then
+		assertThat(businessHours.getContent().size()).isEqualTo(6);
+	}
+}

--- a/src/test/java/com/flab/tabling/businesshour/service/BusinessHourQueryServiceImplTest.java
+++ b/src/test/java/com/flab/tabling/businesshour/service/BusinessHourQueryServiceImplTest.java
@@ -1,0 +1,145 @@
+package com.flab.tabling.businesshour.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.flab.tabling.FixtureFactory;
+import com.flab.tabling.businesshour.BusinessHourFixture;
+import com.flab.tabling.businesshour.domain.BusinessHour;
+import com.flab.tabling.businesshour.dto.BusinessHourFindDto;
+import com.flab.tabling.businesshour.exception.BusinessHourNotFoundException;
+import com.flab.tabling.businesshour.repository.BusinessHourDynamicQueryRepository;
+import com.flab.tabling.businesshour.repository.BusinessHourRepository;
+
+@ExtendWith(MockitoExtension.class)
+class BusinessHourQueryServiceImplTest {
+	@InjectMocks
+	private BusinessHourQueryServiceImpl businessHourQueryServiceImpl;
+	@Mock
+	private BusinessHourRepository businessHourRepository;
+	@Mock
+	private BusinessHourDynamicQueryRepository businessHourDynamicQueryRepository;
+	private BusinessHourFixture businessHourFixture = FixtureFactory.businessHourFixture();
+
+	@Test
+	@DisplayName("운영 시간 단건 조회에 성공하면 응답 Dto를 반환한다.")
+	void successWithCorrectId() {
+		//given
+		BusinessHour businessHour = businessHourFixture.getBusinessHour(2L, 9, 15);
+		Long targetId = businessHour.getId();
+
+		doReturn(Optional.ofNullable(businessHour)).when(businessHourRepository).findById(targetId);
+
+		//when
+		BusinessHourFindDto.Response businessHourFindResponse = businessHourQueryServiceImpl.findBusinessHour(targetId);
+
+		//then
+		assertThat(businessHourFindResponse).usingRecursiveComparison().isEqualTo(
+			new BusinessHourFindDto.Response(businessHour));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 id로 조회한다면 예외가 발생한다.")
+	void failWithNotFoundException() {
+		//given
+		doReturn(Optional.empty()).when(businessHourRepository).findById(2L);
+
+		//expected
+		assertThrows(BusinessHourNotFoundException.class, () -> businessHourQueryServiceImpl.findBusinessHour(2L));
+	}
+
+	@Test
+	@DisplayName("페이지 조건에 맞는 운영 시간 조회에 성공하면 dto 페이지를 반환한다.")
+	void successWithStoreIdAndDayOfWeek() {
+		//given
+		DayOfWeek requestDayOfWeek = businessHourFixture.getDayOfWeek();
+		BusinessHourFindDto.Request businessHourFindRequest = new BusinessHourFindDto.Request(2L, requestDayOfWeek);
+		Page<BusinessHour> businessHourPage = businessHourFixture.getBusinessHourPageWithOneStore(2L);
+		Pageable requestPageable = businessHourPage.getPageable();
+
+		doReturn(businessHourPage).when(businessHourDynamicQueryRepository)
+			.findBusinessHours(2L, requestDayOfWeek, requestPageable);
+
+		//when
+		Page<BusinessHourFindDto.Response> businessHourFindResponsePage = businessHourQueryServiceImpl
+			.findBusinessHours(businessHourFindRequest, requestPageable);
+
+		//then
+		verifyFindResponsePage(businessHourFindResponsePage, businessHourPage);
+	}
+
+	@Test
+	@DisplayName("요청한 시간이 운영 시간이 맞다면 true를 반환한다.")
+	void successWithCorrectBusinessHour() {
+		//given
+		LocalDateTime requestDateTime = businessHourFixture.getLocalDateTime(9);
+		List<BusinessHour> targetBusinessHours = businessHourFixture.getBusinessHoursWithOneStore(2L, 8, 15, 18, 22);
+
+		doReturn(targetBusinessHours).when(businessHourRepository)
+			.findBusinessHours(2L, requestDateTime.getDayOfWeek());
+
+		//when
+		boolean result = businessHourQueryServiceImpl.isBusinessHour(2L, requestDateTime);
+
+		//then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("요청한 시간이 운영 시간이 아니라면 false를 반환한다.")
+	void failWithIncorrectBusinessHour() {
+		//given
+		LocalDateTime requestDateTime = businessHourFixture.getLocalDateTime(16);
+		List<BusinessHour> targetBusinessHours = businessHourFixture.getBusinessHoursWithOneStore(2L, 8, 15, 18, 22);
+
+		doReturn(targetBusinessHours).when(businessHourRepository)
+			.findBusinessHours(2L, requestDateTime.getDayOfWeek());
+
+		//when
+		boolean result = businessHourQueryServiceImpl.isBusinessHour(2L, requestDateTime);
+
+		//then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("요청 조건에 대한 운영 시간이 존재하지 않으면 false를 반환한다.")
+	void failWithEmptyList() {
+		//given
+		LocalDateTime requestDateTime = businessHourFixture.getLocalDateTime(12);
+
+		doReturn(List.of()).when(businessHourRepository).findBusinessHours(2L, requestDateTime.getDayOfWeek());
+
+		//when
+		boolean result = businessHourQueryServiceImpl.isBusinessHour(2L, requestDateTime);
+
+		//then
+		assertThat(result).isFalse();
+	}
+
+	private void verifyFindResponsePage(Page<BusinessHourFindDto.Response> resultBusinessHourPage,
+		Page<BusinessHour> businessHourPage) {
+		List<BusinessHourFindDto.Response> afterContent = resultBusinessHourPage.getContent();
+		List<BusinessHour> beforeContent = businessHourPage.getContent();
+		assertThat(afterContent.size()).isEqualTo(beforeContent.size());
+		assertThat(afterContent.get(0)).usingRecursiveComparison()
+			.isEqualTo(new BusinessHourFindDto.Response(beforeContent.get(0)));
+		assertThat(afterContent.get(1)).usingRecursiveComparison()
+			.isEqualTo(new BusinessHourFindDto.Response(beforeContent.get(1)));
+	}
+}

--- a/src/test/java/com/flab/tabling/store/StoreFixture.java
+++ b/src/test/java/com/flab/tabling/store/StoreFixture.java
@@ -1,0 +1,16 @@
+package com.flab.tabling.store;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.FieldPredicates;
+
+import com.flab.tabling.store.domain.Store;
+
+public class StoreFixture {
+	public Store getStore(Long id) {
+		EasyRandomParameters storeConditions = new EasyRandomParameters()
+			.randomize(FieldPredicates.named("id"), () -> id);
+		EasyRandom storeRandom = new EasyRandom(storeConditions);
+		return storeRandom.nextObject(Store.class);
+	}
+}

--- a/src/test/java/com/flab/tabling/store/service/StoreServiceTest.java
+++ b/src/test/java/com/flab/tabling/store/service/StoreServiceTest.java
@@ -120,9 +120,11 @@ class StoreServiceTest {
 		//then
 		List<StoreFindDto.Response> pageContent = storeFindResponsePage.getContent();
 		StoreFindDto.Response storeAFindResponse = pageContent.get(0);
+		StoreFindDto.Response storeBFindResponse = pageContent.get(1);
 
 		assertThat(pageContent.size()).isEqualTo(2);
-		assertThat(storeAFindResponse.getName()).isEqualTo(storeA.getName());
+		assertThat(storeAFindResponse).usingRecursiveComparison().isEqualTo(new StoreFindDto.Response(storeA));
+		assertThat(storeBFindResponse).usingRecursiveComparison().isEqualTo(new StoreFindDto.Response(storeB));
 	}
 
 	@Test
@@ -146,7 +148,7 @@ class StoreServiceTest {
 	@DisplayName("식당이 존재하고, 요청한 사용자가 식당 주인이 맞다면, 성공적으로 수정되고 응답을 반환한다.")
 	void updateStoreSuccess() {
 		//given
-		Store targetStore = getStoreWithFixedMember();
+		Store targetStore = getStore(2L);
 		StoreUpdateDto.Request storeUpdateRequest = easyRandom.nextObject(StoreUpdateDto.Request.class);
 
 		doReturn(Optional.ofNullable(targetStore)).when(storeRepository).findById(storeUpdateRequest.getId());
@@ -174,7 +176,7 @@ class StoreServiceTest {
 	@DisplayName("요청한 사용자가 식당 주인이 아니라면, 수정은 실패하고 예외가 발생한다.")
 	void updateStoreFailWithNoAuth() {
 		//given
-		Store targetStore = getStoreWithFixedMember();
+		Store targetStore = getStore(2L);
 		StoreUpdateDto.Request storeUpdateRequest = easyRandom.nextObject(StoreUpdateDto.Request.class);
 
 		doReturn(Optional.ofNullable(targetStore)).when(storeRepository).findById(storeUpdateRequest.getId());
@@ -187,7 +189,7 @@ class StoreServiceTest {
 	@DisplayName("식당이 존재하고, 요청자가 식당 주인이라면, 식당은 성공적으로 삭제되고 아무것도 반환하지 않는다.")
 	void deleteStoreSuccess() {
 		//given
-		Store targetStore = getStoreWithFixedMember();
+		Store targetStore = getStore(2L);
 
 		doReturn(Optional.ofNullable(targetStore)).when(storeRepository).findById(2L);
 
@@ -211,7 +213,7 @@ class StoreServiceTest {
 	@Test
 	@DisplayName("요청자가 식당 주인이 아니라면, 삭제는 실패하고 예외가 발생한다.")
 	void deleteStoreFailWithNoAuth() {
-		Store targetStore = getStoreWithFixedMember();
+		Store targetStore = getStore(2L);
 
 		doReturn(Optional.ofNullable(targetStore)).when(storeRepository).findById(2L);
 
@@ -223,7 +225,7 @@ class StoreServiceTest {
 	@DisplayName("요청자가 식당 주인이 맞다면, 검증은 성공하고 아무것도 반환하지 않는다.")
 	void validationSuccess() {
 		//given
-		Store targetStore = getStoreWithFixedMember();
+		Store targetStore = getStore(2L);
 
 		//expected
 		assertDoesNotThrow(() -> storeService.validateAuth(targetStore, 1L));
@@ -233,21 +235,21 @@ class StoreServiceTest {
 	@DisplayName("요청자가 식당 주인이 아니라면, 검증은 실패하고 예외가 발생한다.")
 	void validationFailWithNoAuth() {
 		//given
-		Store targetStore = getStoreWithFixedMember();
+		Store targetStore = getStore(2L);
 
 		//expected
 		assertThrows(AuthorizationException.class, () -> storeService.validateAuth(targetStore, 10L));
 	}
 
-	private Store getStoreWithFixedMember() {
+	private Store getStore(Long id) {
 		EasyRandomParameters storeConditions = new EasyRandomParameters()
-			.randomize(Member.class, () -> getMemberWithFixedId(1L))
-			.randomize(FieldPredicates.named("id"), () -> 2L);
+			.randomize(Member.class, () -> getMember(1L))
+			.randomize(FieldPredicates.named("id"), () -> id);
 		EasyRandom storeRandom = new EasyRandom(storeConditions);
 		return storeRandom.nextObject(Store.class);
 	}
 
-	private Member getMemberWithFixedId(Long id) {
+	private Member getMember(Long id) {
 		EasyRandomParameters memberConditions = new EasyRandomParameters()
 			.randomize(FieldPredicates.named("id"), () -> id);
 		EasyRandom memberRandom = new EasyRandom(memberConditions);


### PR DESCRIPTION
## 작업 사항

* 원활한 협업을 위해 인터페이스 도입
* 단건 조회, 운영 시간 확인 기능 추가
* 동적 쿼리를 사용하기 위해 `Querydsl` 도입

## Self-Check

- [x] 메서드 깊이는 2단계를 유지했습니다.
- [x] else 키워드를 사용하지 않았습니다.
- [x] setter/property를 사용하지 않았습니다.
- [x] 과도하게 줄여쓰지 않았습니다.
