### PR TITLE
[#39] 식당 대기열 기능 Create Delete Update 기능 추가

### DIFF
--- a/src/main/java/com/flab/tabling/global/exception/ErrorCode.java
+++ b/src/main/java/com/flab/tabling/global/exception/ErrorCode.java
@@ -5,14 +5,14 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-	MEMBER_DUPLICATED("member already exists", 400),
+	MEMBER_DUPLICATED("member already exists", 409),
 	MEMBER_NOT_FOUND("member not found", 404),
 	STORE_NOT_FOUND("store not found", 404),
 	INVALID_SESSION("session is invalid", 400),
 	INVALID_PARAMETER("parameter is invalid", 400),
 	AUTHENTICATION_FAILED("authentication failed", 401),
 	AUTHORIZATION_FAILED("authorization failed", 403),
-	PARAMETER_DUPLICATED("given parameter already exists", 400),
+	PARAMETER_DUPLICATED("given parameter already exists", 409),
 	PARAMETER_NOT_FOUND("given parameter not found", 404);
 
 	private final String description;

--- a/src/main/java/com/flab/tabling/global/exception/ErrorCode.java
+++ b/src/main/java/com/flab/tabling/global/exception/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
 	INVALID_SESSION("session is invalid", 400),
 	INVALID_PARAMETER("parameter is invalid", 400),
 	AUTHENTICATION_FAILED("authentication failed", 401),
-	AUTHORIZATION_FAILED("authorization failed", 403);
+	AUTHORIZATION_FAILED("authorization failed", 403),
+	PARAMETER_DUPLICATED("given parameter already exists", 400),
+	PARAMETER_NOT_FOUND("given parameter not found", 404);
 
 	private final String description;
 	private final int status;

--- a/src/main/java/com/flab/tabling/member/service/MemberService.java
+++ b/src/main/java/com/flab/tabling/member/service/MemberService.java
@@ -11,6 +11,7 @@ import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.member.domain.RoleType;
 import com.flab.tabling.member.dto.MemberAddDto;
 import com.flab.tabling.member.exception.MemberDuplicatedException;
+import com.flab.tabling.member.exception.MemberNotFoundException;
 import com.flab.tabling.member.repository.MemberRepository;
 
 import jakarta.servlet.http.HttpSession;
@@ -49,8 +50,8 @@ public class MemberService {
 		return targetMember.getRoleType().equals(RoleType.SELLER); // TODO: 2023-10-09 Member 엔티티 내부에서 처리
 	}
 
-	private Member getMember(Long memberId) {
+	public Member getMember(Long memberId) {
 		return memberRepository.findById(memberId)
-			.orElseThrow(RuntimeException::new); // TODO: 2023-10-04 커스텀 예외로 변경 필요
+			.orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND, "member is not found by given id"));
 	}
 }

--- a/src/main/java/com/flab/tabling/store/service/StoreService.java
+++ b/src/main/java/com/flab/tabling/store/service/StoreService.java
@@ -80,7 +80,7 @@ public class StoreService {
 			.orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND, "member is not found"));
 	}
 
-	private Store getStore(Long storeId) {
+	public Store getStore(Long storeId) {
 		return storeRepository.findById(storeId)
 			.orElseThrow(() -> new StoreNotFoundException(ErrorCode.STORE_NOT_FOUND, "store is not found"));
 	}

--- a/src/main/java/com/flab/tabling/store/web/config/StoreWebConfig.java
+++ b/src/main/java/com/flab/tabling/store/web/config/StoreWebConfig.java
@@ -16,6 +16,7 @@ public class StoreWebConfig implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(storeAuthInterceptor)
+			.excludePathPatterns("/stores/*/waiting/**")
 			.addPathPatterns("/stores/**");
 	}
 }

--- a/src/main/java/com/flab/tabling/store/web/controller/StoreController.java
+++ b/src/main/java/com/flab/tabling/store/web/controller/StoreController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
 
+import com.flab.tabling.global.auth.Login;
+import com.flab.tabling.member.dto.MemberSession;
 import com.flab.tabling.store.dto.StoreAddDto;
 import com.flab.tabling.store.dto.StoreFindDto;
 import com.flab.tabling.store.dto.StoreUpdateDto;
@@ -31,8 +33,8 @@ public class StoreController {
 
 	@PostMapping("/stores")
 	public ResponseEntity<StoreAddDto.Response> add(@Valid @RequestBody StoreAddDto.Request request,
-		@SessionAttribute(name = "LOGIN_SESSION") Long memberId) { // TODO: 2023-10-07 로그인 기능 추가 후 세션 이름 교체
-		StoreAddDto.Response storeResponseDto = storeService.add(request, memberId);
+		@Login MemberSession memberSession) {
+		StoreAddDto.Response storeResponseDto = storeService.add(request, memberSession.getId());
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(storeResponseDto);
 	}
@@ -55,16 +57,16 @@ public class StoreController {
 	@PutMapping("/stores/{id}")
 	public ResponseEntity<StoreUpdateDto.Response> update(
 		@Valid @RequestBody StoreUpdateDto.Request storeUpdateRequest,
-		@SessionAttribute(name = "LOGIN_SESSION") Long sessionMemberId) { // TODO: 2023-10-13 세션 이름 변경 필요
-		StoreUpdateDto.Response storeUpdateResponse = storeService.update(storeUpdateRequest, sessionMemberId);
+		@Login MemberSession memberSession) {
+		StoreUpdateDto.Response storeUpdateResponse = storeService.update(storeUpdateRequest, memberSession.getId());
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(storeUpdateResponse);
 	}
 
 	@DeleteMapping("/stores/{id}")
 	public ResponseEntity<Void> delete(@PathVariable(name = "id") Long storeId,
-		@SessionAttribute(name = "LOGIN_SESSION") Long sessionMemberId) { // TODO: 2023-10-13 세션 이름 변경 필요
-		storeService.delete(storeId, sessionMemberId);
+		@Login MemberSession memberSession) {
+		storeService.delete(storeId, memberSession.getId());
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 
 	}

--- a/src/main/java/com/flab/tabling/store/web/interceptor/StoreAuthInterceptor.java
+++ b/src/main/java/com/flab/tabling/store/web/interceptor/StoreAuthInterceptor.java
@@ -4,6 +4,10 @@ import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import com.flab.tabling.global.constant.SessionConstant;
+import com.flab.tabling.global.exception.AuthorizationException;
+import com.flab.tabling.global.exception.ErrorCode;
+import com.flab.tabling.member.exception.MemberNotFoundException;
 import com.flab.tabling.member.service.MemberService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,31 +27,24 @@ public class StoreAuthInterceptor implements HandlerInterceptor {
 			return true;
 		}
 		HttpSession session = request.getSession();
-		loginValidation(session);
 		memberRoleTypeValidation(session);
 		return true;
-	}
-
-	private void loginValidation(HttpSession session) {
-		if (session == null || session.getAttribute("LOGIN_SESSION") == null) { // TODO: 2023-10-07 로그인 기능 추가 후 세션 이름 교체
-			throw new RuntimeException("NO_SESSION"); // TODO: 2023-10-04 커스텀 인증 예외로 교체 필요
-		}
 	}
 
 	private void memberRoleTypeValidation(HttpSession session) {
 		Long sessionMemberId = getSessionMemberId(session);
 		boolean isSeller = memberService.isSeller(sessionMemberId);
 		if (!isSeller) {
-			throw new RuntimeException("INCORRECT_MEMBER_ROLE_TYPE"); // TODO: 2023-10-06 잘못된 회원 타입을 명시하는 커스텀 예외로 교체
+			throw new AuthorizationException(ErrorCode.AUTHORIZATION_FAILED, "member is not a seller");
 		}
 	}
 
 	private Long getSessionMemberId(HttpSession session) {
-		Object sessionMemberId = session.getAttribute("LOGIN_SESSION");
+		Object sessionMemberId = session.getAttribute(SessionConstant.MEMBER_ID.name());
 		boolean isLongType = sessionMemberId instanceof Long;
 		if (!isLongType) {
-			throw new ClassCastException("Can not cast from " + sessionMemberId + " to Long.class");
+			throw new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND, "member is not found");
 		}
-		return (Long)session.getAttribute("LOGIN_SESSION");
+		return (Long)session.getAttribute(SessionConstant.MEMBER_ID.name());
 	}
 }

--- a/src/main/java/com/flab/tabling/waiting/controller/WaitingController.java
+++ b/src/main/java/com/flab/tabling/waiting/controller/WaitingController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,27 +25,27 @@ public class WaitingController {
 	@PostMapping("/stores/{storeId}/waiting")
 	public ResponseEntity<WaitingAddDto.Response> addMyself(@Login MemberSession memberSession,
 		@PathVariable Long storeId, @Valid @RequestBody WaitingAddDto.Request waitingRequestDto) {
-		WaitingAddDto.Response waitingResponseDto = waitingFacade.addMember(storeId, memberSession.getId(),
+		WaitingAddDto.Response waitingResponseDto = waitingFacade.add(storeId, memberSession.getId(),
 			waitingRequestDto.getHeadCount());
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(waitingResponseDto);
 	}
 
-	@DeleteMapping("/stores/{storeId}/waiting")
+	@DeleteMapping("/stores/{storeId}/waiting/{waitingId}")
 	public ResponseEntity<Void> cancelMyself(@Login MemberSession memberSession,
-		@PathVariable Long storeId) {
-		waitingFacade.cancelMember(storeId, memberSession.getId());
+		@PathVariable Long storeId, @PathVariable Long waitingId) {
+		waitingFacade.cancelMember(storeId, memberSession.getId(), waitingId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
-	@PostMapping("/stores/{storeId}/orders")
+	@PatchMapping("/stores/{storeId}/waiting")
 	public ResponseEntity<Void> acceptFirstByStore(@Login MemberSession memberSession,
 		@PathVariable Long storeId) {
 		waitingFacade.acceptFirst(memberSession.getId(), storeId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
-	@DeleteMapping("/stores/{storeId}/orders")
+	@DeleteMapping("/stores/{storeId}/waiting")
 	public ResponseEntity<Void> cancelFirstByStore(@Login MemberSession memberSession,
 		@PathVariable Long storeId) {
 		waitingFacade.cancelFirst(memberSession.getId(), storeId);

--- a/src/main/java/com/flab/tabling/waiting/controller/WaitingController.java
+++ b/src/main/java/com/flab/tabling/waiting/controller/WaitingController.java
@@ -33,21 +33,21 @@ public class WaitingController {
 	@DeleteMapping("/stores/{storeId}/waiting")
 	public ResponseEntity<Void> cancelMyself(@Login MemberSession memberSession,
 		@PathVariable Long storeId) {
-		waitingFacade.cancelByMySelf(storeId, memberSession.getId());
+		waitingFacade.cancelMember(storeId, memberSession.getId());
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
 	@PostMapping("/stores/{storeId}/orders")
-	public ResponseEntity<Void> acceptFirstOfStore(@Login MemberSession memberSession,
+	public ResponseEntity<Void> acceptFirstByStore(@Login MemberSession memberSession,
 		@PathVariable Long storeId) {
-		waitingFacade.acceptByStore(memberSession.getId(), storeId);
+		waitingFacade.acceptFirst(memberSession.getId(), storeId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
 	@DeleteMapping("/stores/{storeId}/orders")
-	public ResponseEntity<Void> cancelFirstOfStore(@Login MemberSession memberSession,
+	public ResponseEntity<Void> cancelFirstByStore(@Login MemberSession memberSession,
 		@PathVariable Long storeId) {
-		waitingFacade.cancelByStore(memberSession.getId(), storeId);
+		waitingFacade.cancelFirst(memberSession.getId(), storeId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/com/flab/tabling/waiting/controller/WaitingController.java
+++ b/src/main/java/com/flab/tabling/waiting/controller/WaitingController.java
@@ -1,0 +1,53 @@
+package com.flab.tabling.waiting.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.flab.tabling.global.auth.Login;
+import com.flab.tabling.member.dto.MemberSession;
+import com.flab.tabling.waiting.dto.WaitingAddDto;
+import com.flab.tabling.waiting.facade.WaitingFacade;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class WaitingController {
+	private final WaitingFacade waitingFacade;
+
+	@PostMapping("/stores/{storeId}/waiting")
+	public ResponseEntity<WaitingAddDto.Response> addMyself(@Login MemberSession memberSession,
+		@PathVariable Long storeId, @Valid @RequestBody WaitingAddDto.Request waitingRequestDto) {
+		WaitingAddDto.Response waitingResponseDto = waitingFacade.addMember(storeId, memberSession.getId(),
+			waitingRequestDto.getHeadCount());
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(waitingResponseDto);
+	}
+
+	@DeleteMapping("/stores/{storeId}/waiting")
+	public ResponseEntity<Void> cancelMyself(@Login MemberSession memberSession,
+		@PathVariable Long storeId) {
+		waitingFacade.cancelByMySelf(storeId, memberSession.getId());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@PostMapping("/stores/{storeId}/orders")
+	public ResponseEntity<Void> acceptFirstOfStore(@Login MemberSession memberSession,
+		@PathVariable Long storeId) {
+		waitingFacade.acceptByStore(memberSession.getId(), storeId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@DeleteMapping("/stores/{storeId}/orders")
+	public ResponseEntity<Void> cancelFirstOfStore(@Login MemberSession memberSession,
+		@PathVariable Long storeId) {
+		waitingFacade.cancelByStore(memberSession.getId(), storeId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+}

--- a/src/main/java/com/flab/tabling/waiting/domain/Status.java
+++ b/src/main/java/com/flab/tabling/waiting/domain/Status.java
@@ -1,6 +1,0 @@
-package com.flab.tabling.waiting.domain;
-
-public enum Status {
-	WAITING,
-	ENTRANCE
-}

--- a/src/main/java/com/flab/tabling/waiting/domain/Status.java
+++ b/src/main/java/com/flab/tabling/waiting/domain/Status.java
@@ -1,0 +1,6 @@
+package com.flab.tabling.waiting.domain;
+
+public enum Status {
+	WAITING,
+	ENTRANCE
+}

--- a/src/main/java/com/flab/tabling/waiting/domain/Waiting.java
+++ b/src/main/java/com/flab/tabling/waiting/domain/Waiting.java
@@ -16,8 +16,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,7 +40,6 @@ public class Waiting extends BaseTime {
 	private Member member;
 	private Integer headCount;
 	private String uniqueKey;
-
 	@Enumerated(value = EnumType.STRING)
 	private Status status;
 
@@ -56,7 +53,7 @@ public class Waiting extends BaseTime {
 
 	@PrePersist
 	public void generateUniqueKey() {
-		this.uniqueKey = store.getId().toString() + CONJUNCTION + member.getId() + CONJUNCTION + LocalDateTime.now().toLocalDate().toString();
+		this.uniqueKey = store.getId() + CONJUNCTION + member.getId() + CONJUNCTION + LocalDateTime.now().toLocalDate();
 	}
 
 	public void accept() {

--- a/src/main/java/com/flab/tabling/waiting/domain/Waiting.java
+++ b/src/main/java/com/flab/tabling/waiting/domain/Waiting.java
@@ -1,0 +1,65 @@
+package com.flab.tabling.waiting.domain;
+
+import java.time.LocalDateTime;
+
+import com.flab.tabling.global.audit.BaseTime;
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.store.domain.Store;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @PrePersist : 엔티티가 데이터베이스에 저장되기 직전에 호출되는 메소드
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Waiting extends BaseTime {
+	private static final String CONJUNCTION = ":";
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+	private Integer headCount;
+	private String uniqueKey;
+
+	@Enumerated(value = EnumType.STRING)
+	private Status status;
+
+	@Builder
+	public Waiting(Store store, Member member, Integer headCount, Status status) {
+		this.store = store;
+		this.member = member;
+		this.headCount = headCount;
+		this.status = status;
+	}
+
+	@PrePersist
+	public void generateUniqueKey() {
+		this.uniqueKey = store.getId().toString() + CONJUNCTION + member.getId() + CONJUNCTION + LocalDateTime.now().toLocalDate().toString();
+	}
+
+	public void accept() {
+		this.status = Status.ENTRANCE;
+	}
+}

--- a/src/main/java/com/flab/tabling/waiting/domain/Waiting.java
+++ b/src/main/java/com/flab/tabling/waiting/domain/Waiting.java
@@ -39,24 +39,24 @@ public class Waiting extends BaseTime {
 	@JoinColumn(name = "member_id")
 	private Member member;
 	private Integer headCount;
-	private String uniqueKey;
+	private String code;
 	@Enumerated(value = EnumType.STRING)
-	private Status status;
+	private WaitingStatus status;
 
 	@Builder
-	public Waiting(Store store, Member member, Integer headCount, Status status) {
+	public Waiting(Store store, Member member, Integer headCount, WaitingStatus waitingStatus) {
 		this.store = store;
 		this.member = member;
 		this.headCount = headCount;
-		this.status = status;
+		this.status = waitingStatus;
 	}
 
 	@PrePersist
 	public void generateUniqueKey() {
-		this.uniqueKey = store.getId() + CONJUNCTION + member.getId() + CONJUNCTION + LocalDateTime.now().toLocalDate();
+		this.code = store.getId() + CONJUNCTION + member.getId() + CONJUNCTION + LocalDateTime.now().toLocalDate();
 	}
 
 	public void accept() {
-		this.status = Status.ENTRANCE;
+		this.status = WaitingStatus.COMPLETED;
 	}
 }

--- a/src/main/java/com/flab/tabling/waiting/domain/WaitingStatus.java
+++ b/src/main/java/com/flab/tabling/waiting/domain/WaitingStatus.java
@@ -1,0 +1,6 @@
+package com.flab.tabling.waiting.domain;
+
+public enum WaitingStatus {
+	ONGOING,
+	COMPLETED
+}

--- a/src/main/java/com/flab/tabling/waiting/dto/WaitingAddDto.java
+++ b/src/main/java/com/flab/tabling/waiting/dto/WaitingAddDto.java
@@ -1,0 +1,36 @@
+package com.flab.tabling.waiting.dto;
+
+import com.flab.tabling.member.domain.RoleType;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class WaitingAddDto {
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class Request {
+		@NotNull
+		@Min(1) @Max(50)
+		private Integer headCount;
+
+		public Request(Integer headCount) {
+			this.headCount = headCount;
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class Response {
+		private Long id;
+		public Response(Long id) {
+			this.id = id;
+		}
+	}
+}

--- a/src/main/java/com/flab/tabling/waiting/exception/WaitingDuplicatedException.java
+++ b/src/main/java/com/flab/tabling/waiting/exception/WaitingDuplicatedException.java
@@ -1,0 +1,10 @@
+package com.flab.tabling.waiting.exception;
+
+import com.flab.tabling.global.exception.BusinessException;
+import com.flab.tabling.global.exception.ErrorCode;
+
+public class WaitingDuplicatedException extends BusinessException {
+	public WaitingDuplicatedException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+}

--- a/src/main/java/com/flab/tabling/waiting/exception/WaitingExceededException.java
+++ b/src/main/java/com/flab/tabling/waiting/exception/WaitingExceededException.java
@@ -1,0 +1,10 @@
+package com.flab.tabling.waiting.exception;
+
+import com.flab.tabling.global.exception.BusinessException;
+import com.flab.tabling.global.exception.ErrorCode;
+
+public class WaitingExceededException extends BusinessException {
+	public WaitingExceededException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+}

--- a/src/main/java/com/flab/tabling/waiting/exception/WaitingNotFoundException.java
+++ b/src/main/java/com/flab/tabling/waiting/exception/WaitingNotFoundException.java
@@ -1,0 +1,10 @@
+package com.flab.tabling.waiting.exception;
+
+import com.flab.tabling.global.exception.BusinessException;
+import com.flab.tabling.global.exception.ErrorCode;
+
+public class WaitingNotFoundException extends BusinessException {
+	public WaitingNotFoundException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+}

--- a/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
+++ b/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
@@ -23,7 +23,7 @@ public class WaitingFacade {
 	//TODO: Business Hour 검증 로직 추가
 
 	@Transactional
-	public WaitingAddDto.Response addMember(Long storeId, Long memberId, Integer headCount) {
+	public WaitingAddDto.Response add(Long storeId, Long memberId, Integer headCount) {
 		Store store = storeService.getStore(storeId);
 		Member member = memberService.getMember(memberId);
 		Waiting waiting = waitingService.add(store, member, headCount);
@@ -31,10 +31,10 @@ public class WaitingFacade {
 	}
 
 	@Transactional
-	public void cancelMember(Long storeId, Long memberId) {
+	public void cancelMember(Long storeId, Long memberId, Long waitingId) {
 		Store store = storeService.getStore(storeId);
 		Member member = memberService.getMember(memberId);
-		waitingService.cancelMember(store, member);
+		waitingService.cancelMember(store, member, waitingId);
 	}
 
 	@Transactional

--- a/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
+++ b/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
@@ -1,4 +1,5 @@
 package com.flab.tabling.waiting.facade;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,23 +31,24 @@ public class WaitingFacade {
 	}
 
 	@Transactional
-	public void cancelByMySelf(Long storeId, Long memberId) {
+	public void cancelMember(Long storeId, Long memberId) {
 		Store store = storeService.getStore(storeId);
 		Member member = memberService.getMember(memberId);
-		waitingService.cancelMemberOfStore(store, member);
-	}
-	@Transactional
-	public void cancelByStore(Long sellerId, Long storeId) {
-		Store store = storeService.getStore(storeId);
-		storeService.validateAuth(store, sellerId);
-		waitingService.cancelFirstOfStore(store);
+		waitingService.cancelMember(store, member);
 	}
 
 	@Transactional
-	public void acceptByStore(Long sellerId, Long storeId) {
+	public void cancelFirst(Long sellerId, Long storeId) {
 		Store store = storeService.getStore(storeId);
 		storeService.validateAuth(store, sellerId);
-		waitingService.acceptFirstOfStore(store);
+		waitingService.cancelFirst(store);
+	}
+
+	@Transactional
+	public void acceptFirst(Long sellerId, Long storeId) {
+		Store store = storeService.getStore(storeId);
+		storeService.validateAuth(store, sellerId);
+		waitingService.acceptFirst(store);
 	}
 
 }

--- a/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
+++ b/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
@@ -1,0 +1,55 @@
+package com.flab.tabling.waiting.facade;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.member.service.MemberService;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.store.service.StoreService;
+import com.flab.tabling.waiting.domain.Waiting;
+import com.flab.tabling.waiting.dto.WaitingAddDto;
+import com.flab.tabling.waiting.service.WaitingService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingFacade {
+	private final StoreService storeService;
+	private final MemberService memberService;
+	private final WaitingService waitingService;
+	// private final BusinessHourQueryService businessHourQueryService;
+	//TODO: Business Hour 검증 로직 추가
+
+	@Transactional
+	public WaitingAddDto.Response addMember(Long storeId, Long memberId, Integer headCount) {
+		Store store = storeService.getStore(storeId);
+		Member member = memberService.getMember(memberId);
+		Waiting waiting = waitingService.add(store, member, headCount);
+		return new WaitingAddDto.Response(waiting.getId());
+	}
+
+	@Transactional
+	public void cancelByMySelf(Long storeId, Long memberId) {
+		Store store = storeService.getStore(storeId);
+		Member member = memberService.getMember(memberId);
+		waitingService.cancelMemberOfStore(store, member);
+	}
+	@Transactional
+	public void cancelByStore(Long sellerId, Long storeId) {
+		Store store = storeService.getStore(storeId);
+		storeService.validateAuth(store, sellerId);
+		waitingService.cancelFirstOfStore(store);
+	}
+
+	@Transactional
+	public void acceptByStore(Long sellerId, Long storeId) {
+		Store store = storeService.getStore(storeId);
+		storeService.validateAuth(store, sellerId);
+		waitingService.acceptFirstOfStore(store);
+	}
+
+}

--- a/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
+++ b/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
@@ -1,7 +1,4 @@
 package com.flab.tabling.waiting.facade;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
@@ -1,0 +1,38 @@
+package com.flab.tabling.waiting.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.waiting.domain.Status;
+import com.flab.tabling.waiting.domain.Waiting;
+
+import jakarta.persistence.LockModeType;
+
+public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+	public Optional<Waiting> findByMemberAndStoreAndStatus(Member member, Store store, Status status);
+	public Page<Waiting> findPageByStore(Store store, Pageable pageable);
+	public Slice<Waiting> findSliceByStore(Store store, Pageable pageable);
+	public Optional<Waiting> findFirstByStoreAndStatus(Store store, Status status);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select w from Waiting w where w.status=:status and w.store=:store")
+	public Optional<Waiting> findFirstByStoreAndStatusByPessimisticLock(Store store, Status status);
+	@Lock(LockModeType.PESSIMISTIC_READ)
+	public Integer countWithPessimisticLockByStoreAndStatus(Store store, Status status);
+
+	@Override
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	void delete(Waiting waiting);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Override
+	<S extends Waiting> S save(S entity);
+}

--- a/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
@@ -17,16 +17,16 @@ import com.flab.tabling.waiting.domain.Waiting;
 import jakarta.persistence.LockModeType;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
-	public Optional<Waiting> findByMemberAndStoreAndStatus(Member member, Store store, Status status);
-	public Page<Waiting> findPageByStore(Store store, Pageable pageable);
-	public Slice<Waiting> findSliceByStore(Store store, Pageable pageable);
-	public Optional<Waiting> findFirstByStoreAndStatus(Store store, Status status);
+	Optional<Waiting> findByMemberAndStoreAndStatus(Member member, Store store, Status status);
+	Page<Waiting> findPageByStore(Store store, Pageable pageable);
+	Slice<Waiting> findSliceByStore(Store store, Pageable pageable);
+	Optional<Waiting> findFirstByStoreAndStatus(Store store, Status status);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select w from Waiting w where w.status=:status and w.store=:store")
-	public Optional<Waiting> findFirstByStoreAndStatusByPessimisticLock(Store store, Status status);
+	Optional<Waiting> findFirstByStoreAndStatusByPessimisticLock(Store store, Status status);
 	@Lock(LockModeType.PESSIMISTIC_READ)
-	public Integer countWithPessimisticLockByStoreAndStatus(Store store, Status status);
+	Integer countWithPessimisticLockByStoreAndStatus(Store store, Status status);
 
 	@Override
 	@Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
@@ -4,12 +4,11 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
 
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.store.domain.Store;
-import com.flab.tabling.waiting.domain.Status;
 import com.flab.tabling.waiting.domain.Waiting;
+import com.flab.tabling.waiting.domain.WaitingStatus;
 
 import jakarta.persistence.LockModeType;
 
@@ -19,22 +18,13 @@ import jakarta.persistence.LockModeType;
  */
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
-	Optional<Waiting> findByMemberAndStoreAndStatus(Member member, Store store, Status status);
+	Optional<Waiting> findByMemberAndStoreAndStatus(Member member, Store store, WaitingStatus status);
 
-	Optional<Waiting> findFirstByStoreAndStatus(Store store, Status status);
+	Optional<Waiting> findFirstByStoreAndStatusOrderByCreatedAt(Store store, WaitingStatus status);
 
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("select w from Waiting w where w.status=:status and w.store=:store")
-	Optional<Waiting> findFirstByStoreAndStatusByPessimisticLock(Store store, Status status);
+	Optional<Waiting> findFirstByStoreAndStatus(Store store, WaitingStatus status);
 
 	@Lock(LockModeType.PESSIMISTIC_READ)
-	Integer countWithPessimisticLockByStoreAndStatus(Store store, Status status);
+	Integer countWithPessimisticLockByStoreAndStatus(Store store, WaitingStatus status);
 
-	@Override
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	void delete(Waiting waiting);
-
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Override
-	<S extends Waiting> S save(S entity);
 }

--- a/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
@@ -20,11 +20,13 @@ import jakarta.persistence.LockModeType;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 	Optional<Waiting> findByMemberAndStoreAndStatus(Member member, Store store, Status status);
+
 	Optional<Waiting> findFirstByStoreAndStatus(Store store, Status status);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select w from Waiting w where w.status=:status and w.store=:store")
 	Optional<Waiting> findFirstByStoreAndStatusByPessimisticLock(Store store, Status status);
+
 	@Lock(LockModeType.PESSIMISTIC_READ)
 	Integer countWithPessimisticLockByStoreAndStatus(Store store, Status status);
 

--- a/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
@@ -2,9 +2,6 @@ package com.flab.tabling.waiting.repository;
 
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -16,10 +13,13 @@ import com.flab.tabling.waiting.domain.Waiting;
 
 import jakarta.persistence.LockModeType;
 
+/**
+ * @Lock : 비관적 락, 낙관적 락과 관련하여 락 모드를 지정한다.
+ * @Query : JPQL 작성, native=true면 native query 작성
+ */
+
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 	Optional<Waiting> findByMemberAndStoreAndStatus(Member member, Store store, Status status);
-	Page<Waiting> findPageByStore(Store store, Pageable pageable);
-	Slice<Waiting> findSliceByStore(Store store, Pageable pageable);
 	Optional<Waiting> findFirstByStoreAndStatus(Store store, Status status);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/flab/tabling/waiting/service/WaitingService.java
+++ b/src/main/java/com/flab/tabling/waiting/service/WaitingService.java
@@ -1,10 +1,6 @@
 package com.flab.tabling.waiting.service;
 
-import java.util.Optional;
-
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.flab.tabling.global.exception.ErrorCode;
@@ -23,10 +19,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WaitingService {
 	private final WaitingRepository waitingRepository;
+
 	public Waiting add(Store store, Member member, Integer headCount) {
 		checkWaitingQueueFull(store);
 		if (waitingRepository.findByMemberAndStoreAndStatus(member, store, Status.WAITING).isPresent()) {
-			throw new WaitingDuplicatedException(ErrorCode.PARAMETER_DUPLICATED, "waiting for given store already exists");
+			throw new WaitingDuplicatedException(ErrorCode.PARAMETER_DUPLICATED,
+				"waiting for given store already exists");
 		}
 		Waiting waiting = Waiting.builder()
 			.store(store)
@@ -37,26 +35,27 @@ public class WaitingService {
 		try {
 			waitingRepository.save(waiting);
 		} catch (DataIntegrityViolationException e) {
-			throw new WaitingDuplicatedException(ErrorCode.PARAMETER_DUPLICATED, "waiting for given store already exists");
+			throw new WaitingDuplicatedException(ErrorCode.PARAMETER_DUPLICATED,
+				"waiting for given store already exists");
 		}
 		return waiting;
 	}
-
-	public void cancelMemberOfStore(Store store, Member member) {
+	
+	public void cancelMember(Store store, Member member) {
 		Waiting waiting = waitingRepository.findByMemberAndStoreAndStatus(member, store, Status.WAITING)
 			.orElseThrow(() -> new WaitingNotFoundException(ErrorCode.PARAMETER_NOT_FOUND,
 				"waiting for given store not found"));
 		waitingRepository.delete(waiting);
 	}
 
-	public void cancelFirstOfStore(Store store) {
+	public void cancelFirst(Store store) {
 		Waiting waiting = waitingRepository.findFirstByStoreAndStatus(store, Status.WAITING)
 			.orElseThrow(() -> new WaitingNotFoundException(ErrorCode.STORE_NOT_FOUND,
 				"waiting for given store is empty"));
 		waitingRepository.delete(waiting);
 	}
 
-	public void acceptFirstOfStore(Store store) {
+	public void acceptFirst(Store store) {
 		Waiting waiting = waitingRepository.findFirstByStoreAndStatusByPessimisticLock(store, Status.WAITING)
 			.orElseThrow(() -> new WaitingNotFoundException(ErrorCode.STORE_NOT_FOUND,
 				"waiting for given store is empty"));

--- a/src/main/java/com/flab/tabling/waiting/service/WaitingService.java
+++ b/src/main/java/com/flab/tabling/waiting/service/WaitingService.java
@@ -13,6 +13,7 @@ import com.flab.tabling.store.domain.Store;
 import com.flab.tabling.waiting.domain.Status;
 import com.flab.tabling.waiting.domain.Waiting;
 import com.flab.tabling.waiting.exception.WaitingDuplicatedException;
+import com.flab.tabling.waiting.exception.WaitingExceededException;
 import com.flab.tabling.waiting.exception.WaitingNotFoundException;
 import com.flab.tabling.waiting.repository.WaitingRepository;
 
@@ -65,7 +66,7 @@ public class WaitingService {
 	private void checkWaitingQueueFull(Store store) {
 		Integer count = waitingRepository.countWithPessimisticLockByStoreAndStatus(store, Status.WAITING);
 		if (count >= store.getMaxWaitingCount()) {
-			throw new WaitingDuplicatedException(ErrorCode.INVALID_PARAMETER, "waiting queue is full");
+			throw new WaitingExceededException(ErrorCode.INVALID_PARAMETER, "waiting queue is full");
 		}
 	}
 }

--- a/src/main/java/com/flab/tabling/waiting/service/WaitingService.java
+++ b/src/main/java/com/flab/tabling/waiting/service/WaitingService.java
@@ -1,0 +1,71 @@
+package com.flab.tabling.waiting.service;
+
+import java.util.Optional;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.flab.tabling.global.exception.ErrorCode;
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.waiting.domain.Status;
+import com.flab.tabling.waiting.domain.Waiting;
+import com.flab.tabling.waiting.exception.WaitingDuplicatedException;
+import com.flab.tabling.waiting.exception.WaitingNotFoundException;
+import com.flab.tabling.waiting.repository.WaitingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WaitingService {
+	private final WaitingRepository waitingRepository;
+	public Waiting add(Store store, Member member, Integer headCount) {
+		checkWaitingQueueFull(store);
+		if (waitingRepository.findByMemberAndStoreAndStatus(member, store, Status.WAITING).isPresent()) {
+			throw new WaitingDuplicatedException(ErrorCode.PARAMETER_DUPLICATED, "waiting for given store already exists");
+		}
+		Waiting waiting = Waiting.builder()
+			.store(store)
+			.member(member)
+			.headCount(headCount)
+			.status(Status.WAITING)
+			.build();
+		try {
+			waitingRepository.save(waiting);
+		} catch (DataIntegrityViolationException e) {
+			throw new WaitingDuplicatedException(ErrorCode.PARAMETER_DUPLICATED, "waiting for given store already exists");
+		}
+		return waiting;
+	}
+
+	public void cancelMemberOfStore(Store store, Member member) {
+		Waiting waiting = waitingRepository.findByMemberAndStoreAndStatus(member, store, Status.WAITING)
+			.orElseThrow(() -> new WaitingNotFoundException(ErrorCode.PARAMETER_NOT_FOUND,
+				"waiting for given store not found"));
+		waitingRepository.delete(waiting);
+	}
+
+	public void cancelFirstOfStore(Store store) {
+		Waiting waiting = waitingRepository.findFirstByStoreAndStatus(store, Status.WAITING)
+			.orElseThrow(() -> new WaitingNotFoundException(ErrorCode.STORE_NOT_FOUND,
+				"waiting for given store is empty"));
+		waitingRepository.delete(waiting);
+	}
+
+	public void acceptFirstOfStore(Store store) {
+		Waiting waiting = waitingRepository.findFirstByStoreAndStatusByPessimisticLock(store, Status.WAITING)
+			.orElseThrow(() -> new WaitingNotFoundException(ErrorCode.STORE_NOT_FOUND,
+				"waiting for given store is empty"));
+		waiting.accept();
+	}
+
+	private void checkWaitingQueueFull(Store store) {
+		Integer count = waitingRepository.countWithPessimisticLockByStoreAndStatus(store, Status.WAITING);
+		if (count >= store.getMaxWaitingCount()) {
+			throw new WaitingDuplicatedException(ErrorCode.INVALID_PARAMETER, "waiting queue is full");
+		}
+	}
+}

--- a/src/main/resources/h2/data.sql
+++ b/src/main/resources/h2/data.sql
@@ -175,48 +175,48 @@ VALUES (6, 2, 2, '2023-09-27', null, null, null);
 -- 웨이팅
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (1, 1, 4, 3, '2023-09-28', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (1, 1, 4, 3, '2023-09-28', null, null, null, '1:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (2, 1, 5, 4, '2023-09-28', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (2, 1, 5, 4, '2023-09-28', null, null, null, '5:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (3, 1, 6, 6, '2023-09-28', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (3, 1, 6, 6, '2023-09-28', null, null, null, '6:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (4, 2, 7, 2, '2023-09-28', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (4, 2, 7, 2, '2023-09-28', null, null, null, '7:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (5, 2, 8, 1, '2023-09-28', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (5, 2, 8, 1, '2023-09-28', null, null, null, '8:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (6, 3, 9, 4, '2023-09-28', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (6, 3, 9, 4, '2023-09-28', null, null, null, '9:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (7, 3, 10, 2, '2023-09-28', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (7, 3, 10, 2, '2023-09-28', null, null, null, '10:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (8, 1, 7, 2, '2023-09-29', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (8, 1, 7, 2, '2023-10-20 15:30:00', null, null, null, '7:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (9, 3, 4, 2, '2023-09-29', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (9, 3, 4, 2, '2023-10-20 15:30:00', null, null, null, '4:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (10, 3, 5, 4, '2023-09-29', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (10, 3, 5, 4, '2023-10-20 15:30:00', null, null, null, '5:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by)
-VALUES (11, 3, 6, 2, '2023-09-29', null, null, null);
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
+VALUES (11, 3, 6, 2, '2023-10-20 15:30:00', null, null, null, '6:2023-10-20');
 
 -- 공지사항
 INSERT

--- a/src/main/resources/h2/data.sql
+++ b/src/main/resources/h2/data.sql
@@ -175,48 +175,48 @@ VALUES (6, 2, 2, '2023-09-27', null, null, null);
 -- 웨이팅
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (1, 1, 4, 3, '2023-09-28', null, null, null, '1:2023-09-28');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (1, 1, 4, 3, '2023-09-28', null, null, null, '1:1:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (2, 1, 5, 4, '2023-09-28', null, null, null, '5:2023-09-28');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (2, 1, 5, 4, '2023-09-28', null, null, null, '1:5:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (3, 1, 6, 6, '2023-09-28', null, null, null, '6:2023-09-28');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (3, 1, 6, 6, '2023-09-28', null, null, null, '1:6:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (4, 2, 7, 2, '2023-09-28', null, null, null, '7:2023-09-28');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (4, 2, 7, 2, '2023-09-28', null, null, null, '2:7:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (5, 2, 8, 1, '2023-09-28', null, null, null, '8:2023-09-28');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (5, 2, 8, 1, '2023-09-28', null, null, null, '2:8:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (6, 3, 9, 4, '2023-09-28', null, null, null, '9:2023-09-28');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (6, 3, 9, 4, '2023-09-28', null, null, null, '3:9:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (7, 3, 10, 2, '2023-09-28', null, null, null, '10:2023-09-28');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (7, 3, 10, 2, '2023-09-28', null, null, null, '3:10:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (8, 1, 7, 2, '2023-10-20 15:30:00', null, null, null, '7:2023-10-20');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (8, 1, 7, 2, '2023-10-20 15:30:00', null, null, null, '1:7:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (9, 3, 4, 2, '2023-10-20 15:30:00', null, null, null, '4:2023-10-20');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (9, 3, 4, 2, '2023-10-20 15:30:00', null, null, null, '3:4:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (10, 3, 5, 4, '2023-10-20 15:30:00', null, null, null, '5:2023-10-20');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (10, 3, 5, 4, '2023-10-20 15:30:00', null, null, null, '3:5:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, unique_key)
-VALUES (11, 3, 6, 2, '2023-10-20 15:30:00', null, null, null, '6:2023-10-20');
+(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
+VALUES (11, 3, 6, 2, '2023-10-20 15:30:00', null, null, null, '3:6:2023-10-20');
 
 -- 공지사항
 INSERT

--- a/src/main/resources/h2/schema.sql
+++ b/src/main/resources/h2/schema.sql
@@ -68,12 +68,12 @@ CREATE TABLE `waiting`
     `member_id`   bigint  NOT NULL,
     `head_count`  integer NOT NULL COMMENT '예약하는 인원 수',
     `status`      varchar(20),
-    `unique_key`  varchar(50) NOT NULL COMMENT '{member_id}:{created_at}',
+    `code`  varchar(50) NOT NULL COMMENT '{store_id}:{member_id}:{created_at}',
     `created_at`  datetime(6),
     `modified_at` datetime(6),
     `created_by`  varchar(50),
     `modified_by` varchar(50),
-    unique(unique_key)
+    unique(code)
 );
 
 CREATE TABLE `notice`

--- a/src/main/resources/h2/schema.sql
+++ b/src/main/resources/h2/schema.sql
@@ -52,7 +52,7 @@ CREATE TABLE `menu`
 
 CREATE TABLE `favorite`
 (
-    `id`          long PRIMARY KEY,
+    `id`          long PRIMARY KEY AUTO_INCREMENT,
     `store_id`    long NOT NULL,
     `member_id`   long NOT NULL,
     `created_at`  datetime(6),
@@ -63,19 +63,22 @@ CREATE TABLE `favorite`
 
 CREATE TABLE `waiting`
 (
-    `id`          bigint PRIMARY KEY,
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
     `store_id`    bigint  NOT NULL,
     `member_id`   bigint  NOT NULL,
     `head_count`  integer NOT NULL COMMENT '예약하는 인원 수',
+    `status`      varchar(20),
+    `unique_key`  varchar(50) NOT NULL COMMENT '{member_id}:{created_at}',
     `created_at`  datetime(6),
     `modified_at` datetime(6),
     `created_by`  varchar(50),
-    `modified_by` varchar(50)
+    `modified_by` varchar(50),
+    unique(unique_key)
 );
 
 CREATE TABLE `notice`
 (
-    `id`          bigint PRIMARY KEY,
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
     `member_id`   bigint      NOT NULL,
     `title`       varchar(50) NOT NULL,
     `content`     text        NOT NULL,
@@ -88,7 +91,7 @@ CREATE TABLE `notice`
 
 CREATE TABLE `penalty`
 (
-    `id`          bigint PRIMARY KEY,
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
     `member_id`   bigint      NOT NULL,
     `type`        varchar(20),
     `created_at`  datetime(6) NOT NULL,
@@ -99,7 +102,7 @@ CREATE TABLE `penalty`
 
 CREATE TABLE `point`
 (
-    `id`          bigint PRIMARY KEY,
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
     `member_id`   bigint      NOT NULL,
     `amount`      integer     NOT NULL,
     `type`        varchar(20) NOT NULL,
@@ -111,7 +114,7 @@ CREATE TABLE `point`
 
 CREATE TABLE `address`
 (
-    `id`           bigint PRIMARY KEY,
+    `id`           bigint PRIMARY KEY AUTO_INCREMENT,
     `store_id`     bigint,
     `area1`        varchar(20) COMMENT '시도',
     `area2`        varchar(20) COMMENT '시군구',
@@ -127,7 +130,7 @@ CREATE TABLE `address`
 
 CREATE TABLE `history`
 (
-    `id`             bigint PRIMARY KEY,
+    `id`             bigint PRIMARY KEY AUTO_INCREMENT,
     `table_name`     varchar(30),
     `record_id`      bigint,
     `operation_type` varchar(20) COMMENT '상태값',

--- a/src/test/java/com/flab/tabling/store/web/controller/StoreControllerRestDocsTest.java
+++ b/src/test/java/com/flab/tabling/store/web/controller/StoreControllerRestDocsTest.java
@@ -18,10 +18,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.flab.tabling.global.config.AbstractRestDocsTest;
+import com.flab.tabling.global.constant.SessionConstant;
 import com.flab.tabling.store.dto.StoreAddDto;
 import com.flab.tabling.store.dto.StoreFindDto;
 import com.flab.tabling.store.dto.StoreUpdateDto;
@@ -49,11 +51,10 @@ class StoreControllerRestDocsTest extends AbstractRestDocsTest {
 
 		doReturn(responseDto).when(storeService)
 			.add(any(StoreAddDto.Request.class), eq(1L));
-
 		//expected
 		mockMvc.perform(MockMvcRequestBuilders.post("/stores")
 				.contentType(MediaType.APPLICATION_JSON)
-				.sessionAttr("LOGIN_SESSION", 1L) // TODO: 2023-10-07 로그인 기능 추가 후 세션 이름 교체
+				.sessionAttr(SessionConstant.MEMBER_ID.name(), 1L)
 				.content(requestJson)
 			)
 			.andExpect(MockMvcResultMatchers.status().isCreated())
@@ -114,7 +115,7 @@ class StoreControllerRestDocsTest extends AbstractRestDocsTest {
 		//when
 		mockMvc.perform(MockMvcRequestBuilders.put("/stores/{id}", 2L)
 				.contentType(MediaType.APPLICATION_JSON)
-				.sessionAttr("LOGIN_SESSION", 1L) // TODO: 2023-10-13 세션 이름 변경 필요
+				.sessionAttr(SessionConstant.MEMBER_ID.name(), 1L)
 				.content(requestJson)
 			)
 			.andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/com/flab/tabling/store/web/controller/StoreControllerRestDocsTest.java
+++ b/src/test/java/com/flab/tabling/store/web/controller/StoreControllerRestDocsTest.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -28,6 +27,7 @@ import com.flab.tabling.store.dto.StoreAddDto;
 import com.flab.tabling.store.dto.StoreFindDto;
 import com.flab.tabling.store.dto.StoreUpdateDto;
 import com.flab.tabling.store.service.StoreService;
+
 @WebMvcTest(StoreController.class)
 class StoreControllerRestDocsTest extends AbstractRestDocsTest {
 
@@ -50,7 +50,7 @@ class StoreControllerRestDocsTest extends AbstractRestDocsTest {
 		String responseJson = objectMapper.writeValueAsString(responseDto);
 
 		doReturn(responseDto).when(storeService)
-			.add(any(StoreAddDto.Request.class), eq(1L));
+			.add(any(), any());
 		//expected
 		mockMvc.perform(MockMvcRequestBuilders.post("/stores")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -110,7 +110,7 @@ class StoreControllerRestDocsTest extends AbstractRestDocsTest {
 		StoreUpdateDto.Response storeUpdateResponse = easyRandom.nextObject(StoreUpdateDto.Response.class);
 		String responseJson = objectMapper.writeValueAsString(storeUpdateResponse);
 
-		doReturn(storeUpdateResponse).when(storeService).update(any(StoreUpdateDto.Request.class), eq(1L));
+		doReturn(storeUpdateResponse).when(storeService).update(any(), any());
 
 		//when
 		mockMvc.perform(MockMvcRequestBuilders.put("/stores/{id}", 2L)
@@ -128,7 +128,7 @@ class StoreControllerRestDocsTest extends AbstractRestDocsTest {
 		//expected
 		mockMvc.perform(MockMvcRequestBuilders.delete("/stores/{id}", 2L)
 				.contentType(MediaType.APPLICATION_JSON)
-				.sessionAttr("LOGIN_SESSION", 1L) // TODO: 2023-10-13 세션 이름 변경 필요
+				.sessionAttr(SessionConstant.MEMBER_ID.name(), 1L)
 			)
 			.andExpect(MockMvcResultMatchers.status().isNoContent());
 	}

--- a/src/test/java/com/flab/tabling/store/web/controller/StoreControllerTest.java
+++ b/src/test/java/com/flab/tabling/store/web/controller/StoreControllerTest.java
@@ -69,7 +69,7 @@ class StoreControllerTest {
 		String responseJson = objectMapper.writeValueAsString(responseDto);
 
 		doReturn(responseDto).when(storeService)
-			.add(any(StoreAddDto.Request.class), eq(1L));
+			.add(any(), any());
 
 		//expected
 		mockMvc.perform(MockMvcRequestBuilders.post("/stores")
@@ -130,7 +130,7 @@ class StoreControllerTest {
 		StoreUpdateDto.Response storeUpdateResponse = easyRandom.nextObject(StoreUpdateDto.Response.class);
 		String responseJson = objectMapper.writeValueAsString(storeUpdateResponse);
 
-		doReturn(storeUpdateResponse).when(storeService).update(any(StoreUpdateDto.Request.class), eq(1L));
+		doReturn(storeUpdateResponse).when(storeService).update(any(), any());
 
 		//when
 		mockMvc.perform(MockMvcRequestBuilders.put("/stores/{id}", 2L)

--- a/src/test/java/com/flab/tabling/store/web/controller/StoreControllerTest.java
+++ b/src/test/java/com/flab/tabling/store/web/controller/StoreControllerTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.tabling.global.constant.SessionConstant;
 import com.flab.tabling.store.dto.StoreAddDto;
 import com.flab.tabling.store.dto.StoreFindDto;
 import com.flab.tabling.store.dto.StoreUpdateDto;
@@ -73,7 +74,7 @@ class StoreControllerTest {
 		//expected
 		mockMvc.perform(MockMvcRequestBuilders.post("/stores")
 				.contentType(MediaType.APPLICATION_JSON)
-				.sessionAttr("LOGIN_SESSION", 1L) // TODO: 2023-10-07 로그인 기능 추가 후 세션 이름 교체
+				.sessionAttr(SessionConstant.MEMBER_ID.name(), 1L)
 				.content(requestJson)
 			)
 			.andExpect(MockMvcResultMatchers.status().isCreated())
@@ -134,7 +135,7 @@ class StoreControllerTest {
 		//when
 		mockMvc.perform(MockMvcRequestBuilders.put("/stores/{id}", 2L)
 				.contentType(MediaType.APPLICATION_JSON)
-				.sessionAttr("LOGIN_SESSION", 1L) // TODO: 2023-10-13 세션 이름 변경 필요
+				.sessionAttr(SessionConstant.MEMBER_ID.name(), 1L)
 				.content(requestJson)
 			)
 			.andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/com/flab/tabling/store/web/interceptor/StoreAuthInterceptorTest.java
+++ b/src/test/java/com/flab/tabling/store/web/interceptor/StoreAuthInterceptorTest.java
@@ -15,6 +15,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 
+import com.flab.tabling.global.constant.SessionConstant;
+import com.flab.tabling.member.exception.MemberNotFoundException;
 import com.flab.tabling.member.service.MemberService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -46,7 +48,7 @@ class StoreAuthInterceptorTest {
 	void authSuccessWithSeller() throws Exception {
 		//given
 		MockHttpSession sessionMock = new MockHttpSession();
-		sessionMock.setAttribute("LOGIN_SESSION", 1L); // TODO: 2023-10-07 로그인 기능 추가 후 세션 이름 교체
+		sessionMock.setAttribute(SessionConstant.MEMBER_ID.name(), 1L);
 
 		MockHttpServletRequest requestMock = new MockHttpServletRequest();
 		requestMock.setMethod(HttpMethod.POST.name());
@@ -67,7 +69,7 @@ class StoreAuthInterceptorTest {
 		//given
 		HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
 		MockHttpSession sessionMock = new MockHttpSession();
-		sessionMock.setAttribute("LOGIN_SESSION", 1L); // TODO: 2023-10-07 로그인 기능 추가 후 세션 이름 교체
+		sessionMock.setAttribute(SessionConstant.MEMBER_ID.name(), 1L);
 
 		doReturn(sessionMock).when(requestMock)
 			.getSession();
@@ -83,14 +85,14 @@ class StoreAuthInterceptorTest {
 	void canNotCastSessionMemberId() {
 		//given
 		MockHttpSession sessionMock = new MockHttpSession();
-		sessionMock.setAttribute("LOGIN_SESSION", NOT_LONG_TYPE); // TODO: 2023-10-07 로그인 기능 추가 후 세션 이름 교체
+		sessionMock.setAttribute(SessionConstant.MEMBER_ID.name(), NOT_LONG_TYPE);
 
 		MockHttpServletRequest requestMock = new MockHttpServletRequest();
 		requestMock.setMethod(HttpMethod.POST.name());
 		requestMock.setSession(sessionMock);
 
 		//expected
-		assertThrows(ClassCastException.class, () -> storeAuthInterceptor.preHandle(requestMock, null, null));
+		assertThrows(MemberNotFoundException.class, () -> storeAuthInterceptor.preHandle(requestMock, null, null));
 	}
 
 	@Test

--- a/src/test/java/com/flab/tabling/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/flab/tabling/waiting/controller/WaitingControllerTest.java
@@ -35,7 +35,7 @@ class WaitingControllerTest extends AbstractRestDocsTest {
 
 		//when
 		WaitingAddDto.Response waitingResponseDto = new WaitingAddDto.Response(13L);
-		doReturn(waitingResponseDto).when(waitingFacade).addMember(any(), any(), any());
+		doReturn(waitingResponseDto).when(waitingFacade).add(any(), any(), any());
 		MockHttpServletResponse response = mockMvc.perform(post("/stores/1/waiting")
 				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
@@ -56,7 +56,7 @@ class WaitingControllerTest extends AbstractRestDocsTest {
 		session.setAttribute(SessionConstant.MEMBER_ID.name(), 3L);
 
 		//when, then
-		mockMvc.perform(delete("/stores/{id}/waiting", 2L)
+		mockMvc.perform(delete("/stores/{store_id}/waiting/{waiting_id}", 2L, 10L)
 				.session(session)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNoContent());
@@ -69,8 +69,8 @@ class WaitingControllerTest extends AbstractRestDocsTest {
 
 		//when
 		WaitingAddDto.Response waitingResponseDto = new WaitingAddDto.Response(13L);
-		doReturn(waitingResponseDto).when(waitingFacade).addMember(any(), any(), any());
-		mockMvc.perform(post("/stores/{id}/orders", 2L)
+		doReturn(waitingResponseDto).when(waitingFacade).add(any(), any(), any());
+		mockMvc.perform(patch("/stores/{storeId}/waiting", 2L)
 				.session(session)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNoContent())
@@ -84,8 +84,8 @@ class WaitingControllerTest extends AbstractRestDocsTest {
 
 		//when
 		WaitingAddDto.Response waitingResponseDto = new WaitingAddDto.Response(13L);
-		doReturn(waitingResponseDto).when(waitingFacade).addMember(any(), any(), any());
-		mockMvc.perform(delete("/stores/{id}/orders", 2L)
+		doReturn(waitingResponseDto).when(waitingFacade).add(any(), any(), any());
+		mockMvc.perform(delete("/stores/{storeId}/waiting", 2L)
 				.session(session)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNoContent())

--- a/src/test/java/com/flab/tabling/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/flab/tabling/waiting/controller/WaitingControllerTest.java
@@ -1,0 +1,94 @@
+package com.flab.tabling.waiting.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+import com.flab.tabling.global.config.AbstractRestDocsTest;
+import com.flab.tabling.global.constant.SessionConstant;
+import com.flab.tabling.waiting.dto.WaitingAddDto;
+import com.flab.tabling.waiting.facade.WaitingFacade;
+
+@WebMvcTest(WaitingController.class)
+class WaitingControllerTest extends AbstractRestDocsTest {
+	@MockBean
+	WaitingFacade waitingFacade;
+
+	private MockHttpSession session = new MockHttpSession();
+
+	@Test
+	@DisplayName("사용자 식당 대기 신청 성공")
+	void addMySelf() throws Exception {
+		//given
+		WaitingAddDto.Request waitingRequestDto = new WaitingAddDto.Request(3);
+		session.setAttribute(SessionConstant.MEMBER_ID.name(), 3L);
+
+		//when
+		WaitingAddDto.Response waitingResponseDto = new WaitingAddDto.Response(13L);
+		doReturn(waitingResponseDto).when(waitingFacade).addMember(any(), any(), any());
+		MockHttpServletResponse response = mockMvc.perform(post("/stores/1/waiting")
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(waitingRequestDto)))
+			.andExpect(status().isCreated())
+			.andReturn().getResponse();
+		WaitingAddDto.Response result = objectMapper.readValue(response.getContentAsString(),
+			WaitingAddDto.Response.class);
+
+		//then
+		assertThat(result).usingRecursiveComparison().isEqualTo(waitingResponseDto);
+	}
+
+	@Test
+	@DisplayName("사용자 식당 대기 취소 성공")
+	void cancelMyself() throws Exception {
+		//given
+		session.setAttribute(SessionConstant.MEMBER_ID.name(), 3L);
+
+		//when, then
+		mockMvc.perform(delete("/stores/{id}/waiting", 2L)
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void acceptFirstOfStore() throws Exception {
+		//given
+		session.setAttribute(SessionConstant.MEMBER_ID.name(), 3L);
+
+		//when
+		WaitingAddDto.Response waitingResponseDto = new WaitingAddDto.Response(13L);
+		doReturn(waitingResponseDto).when(waitingFacade).addMember(any(), any(), any());
+		mockMvc.perform(post("/stores/{id}/orders", 2L)
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNoContent())
+			.andReturn().getResponse();
+	}
+
+	@Test
+	void cancelFirstOfStore() throws Exception {
+		//given
+		session.setAttribute(SessionConstant.MEMBER_ID.name(), 3L);
+
+		//when
+		WaitingAddDto.Response waitingResponseDto = new WaitingAddDto.Response(13L);
+		doReturn(waitingResponseDto).when(waitingFacade).addMember(any(), any(), any());
+		mockMvc.perform(delete("/stores/{id}/orders", 2L)
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNoContent())
+			.andReturn().getResponse();
+	}
+}

--- a/src/test/java/com/flab/tabling/waiting/domain/WaitingTest.java
+++ b/src/test/java/com/flab/tabling/waiting/domain/WaitingTest.java
@@ -23,7 +23,7 @@ class WaitingTest {
 		waiting.generateUniqueKey();
 
 		//then
-		Assertions.assertThat(waiting.getUniqueKey())
+		Assertions.assertThat(waiting.getCode())
 			.isEqualTo(store.getId() + CONJUNCTION + member.getId() + CONJUNCTION + LocalDateTime.now().toLocalDate());
 	}
 }

--- a/src/test/java/com/flab/tabling/waiting/domain/WaitingTest.java
+++ b/src/test/java/com/flab/tabling/waiting/domain/WaitingTest.java
@@ -1,0 +1,29 @@
+package com.flab.tabling.waiting.domain;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.waiting.fixture.WaitingFixture;
+
+class WaitingTest {
+	private static final String CONJUNCTION = ":";
+
+	@Test
+	void generateUniqueKey() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(member);
+		Waiting waiting = WaitingFixture.getWaiting(store, member);
+
+		//when
+		waiting.generateUniqueKey();
+
+		//then
+		Assertions.assertThat(waiting.getUniqueKey())
+			.isEqualTo(store.getId() + CONJUNCTION + member.getId() + CONJUNCTION + LocalDateTime.now().toLocalDate());
+	}
+}

--- a/src/test/java/com/flab/tabling/waiting/facade/WaitingFacadeTest.java
+++ b/src/test/java/com/flab/tabling/waiting/facade/WaitingFacadeTest.java
@@ -50,7 +50,7 @@ class WaitingFacadeTest {
 		doReturn(waiting).when(waitingService).add(store, member, headCount);
 
 		//then
-		Assertions.assertThat(waitingFacade.addMember(storeId, memberId, headCount))
+		Assertions.assertThat(waitingFacade.add(storeId, memberId, headCount))
 			.usingRecursiveComparison().isEqualTo(new WaitingAddDto.Response(waiting.getId()));
 	}
 
@@ -60,14 +60,15 @@ class WaitingFacadeTest {
 		//given
 		Member member = WaitingFixture.getMember();
 		Store store = WaitingFixture.getStore(member);
+		Waiting waiting = WaitingFixture.getWaiting(store, member);
 
 		//when
-		waitingFacade.cancelMember(store.getId(), member.getId());
+		waitingFacade.cancelMember(store.getId(), member.getId(), waiting.getId());
 
 		//then
 		verify(storeService).getStore(anyLong());
 		verify(memberService).getMember(anyLong());
-		verify(waitingService).cancelMember(any(), any());
+		verify(waitingService).cancelMember(any(), any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/flab/tabling/waiting/facade/WaitingFacadeTest.java
+++ b/src/test/java/com/flab/tabling/waiting/facade/WaitingFacadeTest.java
@@ -1,0 +1,134 @@
+package com.flab.tabling.waiting.facade;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flab.tabling.global.exception.AuthorizationException;
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.member.service.MemberService;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.store.service.StoreService;
+import com.flab.tabling.waiting.domain.Waiting;
+import com.flab.tabling.waiting.dto.WaitingAddDto;
+import com.flab.tabling.waiting.fixture.WaitingFixture;
+import com.flab.tabling.waiting.service.WaitingService;
+
+@ExtendWith(MockitoExtension.class)
+class WaitingFacadeTest {
+
+	@InjectMocks
+	WaitingFacade waitingFacade;
+	@Mock
+	StoreService storeService;
+	@Mock
+	MemberService memberService;
+	@Mock
+	WaitingService waitingService;
+
+	@Test
+	@DisplayName("사용자 식당 대기열 추가 성공")
+	void successAddMember() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(member);
+		Waiting waiting = WaitingFixture.getWaiting(store, member);
+		Long storeId = store.getId();
+		Long memberId = member.getId();
+		Integer headCount = waiting.getHeadCount();
+
+		//when
+		doReturn(store).when(storeService).getStore(storeId);
+		doReturn(member).when(memberService).getMember(memberId);
+		doReturn(waiting).when(waitingService).add(store, member, headCount);
+
+		//then
+		Assertions.assertThat(waitingFacade.addMember(storeId, memberId, headCount))
+			.usingRecursiveComparison().isEqualTo(new WaitingAddDto.Response(waiting.getId()));
+	}
+
+	@Test
+	@DisplayName("사용자 식당 대기열 삭제 성공")
+	void successCancelByMySelf() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(member);
+
+		//when
+		waitingFacade.cancelMember(store.getId(), member.getId());
+
+		//then
+		verify(storeService).getStore(anyLong());
+		verify(memberService).getMember(anyLong());
+		verify(waitingService).cancelMember(any(), any());
+	}
+
+	@Test
+	@DisplayName("식당이 대기열에서 첫번째 고객 예약 취소 성공")
+	void successCancelByStore() {
+		//given
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+
+		//when
+		waitingFacade.cancelFirst(store.getId(), seller.getId());
+
+		//then
+		verify(storeService).getStore(anyLong());
+		verify(storeService).validateAuth(any(), anyLong());
+		verify(waitingService).cancelFirst(any());
+	}
+
+	@Test
+	@DisplayName("식당이 대기열에서 첫번째 고객 입장 실패")
+	void failCancelByStore() {
+		//given
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+
+		//when
+		doReturn(store).when(storeService).getStore(store.getId());
+		doThrow(AuthorizationException.class).when(storeService).validateAuth(store, seller.getId());
+
+		//then
+		assertThrows(AuthorizationException.class, () -> waitingFacade.cancelFirst(seller.getId(), store.getId()));
+	}
+
+	@Test
+	@DisplayName("식당이 대기열에서 첫번째 고객 입장 성공")
+	void successAcceptByStore() {
+		//given
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+
+		//when
+		waitingFacade.acceptFirst(store.getId(), seller.getId());
+
+		//then
+		verify(storeService).getStore(anyLong());
+		verify(storeService).validateAuth(any(), anyLong());
+		verify(waitingService).acceptFirst(any());
+	}
+
+	@Test
+	@DisplayName("식당이 대기열에서 첫번째 고객 입장 실패")
+	void failAcceptByStore() {
+		//given
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+
+		//when
+		doReturn(store).when(storeService).getStore(store.getId());
+		doThrow(AuthorizationException.class).when(storeService).validateAuth(store, seller.getId());
+
+		//then
+		assertThrows(AuthorizationException.class, () -> waitingFacade.acceptFirst(seller.getId(), store.getId()));
+	}
+}

--- a/src/test/java/com/flab/tabling/waiting/fixture/WaitingFixture.java
+++ b/src/test/java/com/flab/tabling/waiting/fixture/WaitingFixture.java
@@ -1,19 +1,16 @@
 package com.flab.tabling.waiting.fixture;
 
 import org.jeasy.random.EasyRandom;
-import org.jeasy.random.EasyRandomParameters;
-import org.jeasy.random.randomizers.number.AtomicLongRandomizer;
 import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
 import org.jeasy.random.randomizers.range.LongRangeRandomizer;
 import org.jeasy.random.randomizers.text.StringRandomizer;
-import org.junit.jupiter.api.Test;
 
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.member.domain.RoleType;
 import com.flab.tabling.store.domain.Category;
 import com.flab.tabling.store.domain.Store;
-import com.flab.tabling.waiting.domain.Status;
 import com.flab.tabling.waiting.domain.Waiting;
+import com.flab.tabling.waiting.domain.WaitingStatus;
 
 public final class WaitingFixture {
 	private static EasyRandom easyRandom = new EasyRandom();
@@ -22,7 +19,7 @@ public final class WaitingFixture {
 	private static IntegerRangeRandomizer integerRangeRandomizer = new IntegerRangeRandomizer(1, 10);
 
 	public static Waiting getWaiting(Store store, Member member) {
-		return new MockWaiting(store, member, integerRangeRandomizer.getRandomValue(), Status.WAITING);
+		return new MockWaiting(store, member, integerRangeRandomizer.getRandomValue(), WaitingStatus.ONGOING);
 	}
 
 	public static Store getStore(Member member) {
@@ -35,9 +32,9 @@ public final class WaitingFixture {
 			stringRandomizer.getRandomValue(), easyRandom.nextObject(RoleType.class));
 	}
 
-
 	private static class MockStore extends Store {
 		private Long mockId = longRangeRandomizer.getRandomValue();
+
 		private MockStore(Member member, String name, Category category, String description,
 			Integer maxWaitingCount) {
 			super(member, name, category, description, maxWaitingCount);
@@ -51,6 +48,7 @@ public final class WaitingFixture {
 
 	private static class MockMember extends Member {
 		private Long mockId = longRangeRandomizer.getRandomValue();
+
 		private MockMember(String name, String email, String password, RoleType roleType) {
 			super(name, email, password, roleType);
 		}
@@ -63,7 +61,8 @@ public final class WaitingFixture {
 
 	private static class MockWaiting extends Waiting {
 		private Long mockId = longRangeRandomizer.getRandomValue();
-		public MockWaiting(Store store, Member member, Integer headCount, Status status) {
+
+		public MockWaiting(Store store, Member member, Integer headCount, WaitingStatus status) {
 			super(store, member, headCount, status);
 		}
 
@@ -72,6 +71,5 @@ public final class WaitingFixture {
 			return mockId;
 		}
 	}
-
 
 }

--- a/src/test/java/com/flab/tabling/waiting/fixture/WaitingFixture.java
+++ b/src/test/java/com/flab/tabling/waiting/fixture/WaitingFixture.java
@@ -1,0 +1,77 @@
+package com.flab.tabling.waiting.fixture;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.randomizers.number.AtomicLongRandomizer;
+import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
+import org.jeasy.random.randomizers.range.LongRangeRandomizer;
+import org.jeasy.random.randomizers.text.StringRandomizer;
+import org.junit.jupiter.api.Test;
+
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.member.domain.RoleType;
+import com.flab.tabling.store.domain.Category;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.waiting.domain.Status;
+import com.flab.tabling.waiting.domain.Waiting;
+
+public final class WaitingFixture {
+	private static EasyRandom easyRandom = new EasyRandom();
+	private static StringRandomizer stringRandomizer = new StringRandomizer(30);
+	private static LongRangeRandomizer longRangeRandomizer = new LongRangeRandomizer(1L, 1000L);
+	private static IntegerRangeRandomizer integerRangeRandomizer = new IntegerRangeRandomizer(1, 10);
+
+	public static Waiting getWaiting(Store store, Member member) {
+		return new MockWaiting(store, member, integerRangeRandomizer.getRandomValue(), Status.WAITING);
+	}
+
+	public static Store getStore(Member member) {
+		return new MockStore(member, stringRandomizer.getRandomValue(), easyRandom.nextObject(Category.class),
+			stringRandomizer.getRandomValue(), longRangeRandomizer.getRandomValue().intValue());
+	}
+
+	public static Member getMember() {
+		return new MockMember(stringRandomizer.getRandomValue(), stringRandomizer.getRandomValue(),
+			stringRandomizer.getRandomValue(), easyRandom.nextObject(RoleType.class));
+	}
+
+
+	private static class MockStore extends Store {
+		private Long mockId = longRangeRandomizer.getRandomValue();
+		private MockStore(Member member, String name, Category category, String description,
+			Integer maxWaitingCount) {
+			super(member, name, category, description, maxWaitingCount);
+		}
+
+		@Override
+		public Long getId() {
+			return mockId;
+		}
+	}
+
+	private static class MockMember extends Member {
+		private Long mockId = longRangeRandomizer.getRandomValue();
+		private MockMember(String name, String email, String password, RoleType roleType) {
+			super(name, email, password, roleType);
+		}
+
+		@Override
+		public Long getId() {
+			return mockId;
+		}
+	}
+
+	private static class MockWaiting extends Waiting {
+		private Long mockId = longRangeRandomizer.getRandomValue();
+		public MockWaiting(Store store, Member member, Integer headCount, Status status) {
+			super(store, member, headCount, status);
+		}
+
+		@Override
+		public Long getId() {
+			return mockId;
+		}
+	}
+
+
+}

--- a/src/test/java/com/flab/tabling/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/flab/tabling/waiting/service/WaitingServiceTest.java
@@ -1,0 +1,152 @@
+package com.flab.tabling.waiting.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.waiting.domain.Status;
+import com.flab.tabling.waiting.domain.Waiting;
+import com.flab.tabling.waiting.exception.WaitingExceededException;
+import com.flab.tabling.waiting.exception.WaitingNotFoundException;
+import com.flab.tabling.waiting.fixture.WaitingFixture;
+import com.flab.tabling.waiting.repository.WaitingRepository;
+
+@ExtendWith(MockitoExtension.class)
+class WaitingServiceTest {
+
+	@InjectMocks
+	WaitingService waitingService;
+
+	@Mock
+	WaitingRepository waitingRepository;
+
+
+	@Test
+	@DisplayName("대기열 멤버 추가 성공")
+	void successAddMember() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+		Waiting waiting = WaitingFixture.getWaiting(store, member);
+		doReturn(Optional.empty()).when(waitingRepository).findByMemberAndStoreAndStatus(member, store, Status.WAITING);
+
+		//when
+		Waiting result = waitingService.add(store, member, waiting.getHeadCount());
+		//then
+		Assertions.assertThat(List.of(waiting.getMember(), waiting.getStore(), waiting.getHeadCount()))
+				.isEqualTo(List.of(result.getMember(), result.getStore(), result.getHeadCount()));
+		verify(waitingRepository).save(any(Waiting.class));
+	}
+
+	@Test
+	@DisplayName("대기열 멤버 추가 실패 : 최대 인원수 초과")
+	void failAddMemberByExceedingMaxLimit() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+		Waiting waiting = WaitingFixture.getWaiting(store, member);
+		doReturn(store.getMaxWaitingCount() + 10).when(waitingRepository).countWithPessimisticLockByStoreAndStatus(store, Status.WAITING);
+		//when, then
+		assertThrows(WaitingExceededException.class, () -> waitingService.add(store, member, waiting.getHeadCount()));
+	}
+
+	@Test
+	@DisplayName("대기열 멤버 삭제 성공")
+	void successCancelMemberOfStore() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+		Waiting waiting = WaitingFixture.getWaiting(store, member);
+		doReturn(Optional.of(waiting)).when(waitingRepository).findByMemberAndStoreAndStatus(member, store, Status.WAITING);
+
+		//when
+		waitingService.cancelMember(store, member);
+
+		//then
+		verify(waitingRepository).delete(any(Waiting.class));
+	}
+
+	@Test
+	@DisplayName("대기열 멤버 삭제 실패")
+	void failCancelMemberOfStore() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+		doReturn(Optional.empty()).when(waitingRepository).findByMemberAndStoreAndStatus(member, store, Status.WAITING);
+
+		//when, then
+		assertThrows(WaitingNotFoundException.class, () -> waitingService.cancelMember(store, member));
+	}
+
+	@Test
+	@DisplayName("가게의 대기열 첫번째 멤버 삭제 성공")
+	void successCancelFirstOfStore() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+		Waiting waiting = WaitingFixture.getWaiting(store, member);
+		doReturn(Optional.of(waiting)).when(waitingRepository).findFirstByStoreAndStatus(store, Status.WAITING);
+
+		waitingService.cancelFirst(store);
+		//when, then
+		verify(waitingRepository).delete(any(Waiting.class));
+	}
+
+	@Test
+	@DisplayName("가게의 대기열 첫번째 멤버 삭제 실패")
+	void failCancelFirstOfStore() {
+		//given
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+		doReturn(Optional.empty()).when(waitingRepository).findFirstByStoreAndStatus(store, Status.WAITING);
+
+		//when, then
+		assertThrows(WaitingNotFoundException.class, () -> waitingService.cancelFirst(store));
+	}
+
+	@Test
+	@DisplayName("가게의 대기열 첫번째 멤버 입장 성공")
+	void successAcceptFirstOfStore() {
+		//given
+		Member member = WaitingFixture.getMember();
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+		Waiting waiting = WaitingFixture.getWaiting(store, member);
+		doReturn(Optional.of(waiting)).when(waitingRepository).findFirstByStoreAndStatusByPessimisticLock(store, Status.WAITING);
+
+		//when
+		waitingService.acceptFirst(store);
+
+		//then
+		Assertions.assertThat(waiting.getStatus()).isEqualTo(Status.ENTRANCE);
+	}
+
+	@Test
+	@DisplayName("가게의 대기열 첫번째 멤버 입장 성공")
+	void failAcceptFirstOfStore() {
+		//given
+		Member seller = WaitingFixture.getMember();
+		Store store = WaitingFixture.getStore(seller);
+		doReturn(Optional.empty()).when(waitingRepository).findFirstByStoreAndStatusByPessimisticLock(store, Status.WAITING);
+
+		//when, then
+		assertThrows(WaitingNotFoundException.class, () -> waitingService.acceptFirst(store));
+	}
+}


### PR DESCRIPTION
## 작업 사항
* 사용자의 식당 대기 신청, 삭제, 식당의 대기 손님 입장 처리, 식당의 대기 손님 입장 취소 기능 추가 
* 동시성 처리: Waiting에 unique key 추가, 비관적 락 추가
* Waiting 테이블 구조 수정 : unique_key, status(Waiting 상태) 추가
* Waiting 구현 시 Store 부분 사용해서 Store 관련 세션 설정 수정
* Facade 패턴 : WaitingFacade 두고 그 아래에 WaitingService두고, WaitingService를 통해서만 Waiting Repository로 접근하게끔 했습니다. 
* 수정 후 Store Controller 테스트 2개가 터지는데 한번 확인해봐야 할것 같습니다..

## Self-Check

- [X] 메서드 깊이는 2단계를 유지했습니다.
- [X] else 키워드를 사용하지 않았습니다.
- [X] setter/property를 사용하지 않았습니다.
- [X] 과도하게 줄여쓰지 않았습니다.
