### PR TITLE
[#46] 로그 패턴 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ jacocoTestCoverageVerification {
                     'com.flab.tabling.global.constant.**',
                     'com.flab.tabling.global.auth.ExceptionHandlerFilter',
                     'com.flab.tabling.global.auth.Login*',
+                    'com.flab.tabling.global.log.MdcLoggingFilter',
                     'com.flab.tabling.**.domain.Q*',
             ]
         }

--- a/src/main/java/com/flab/tabling/global/config/LogConfig.java
+++ b/src/main/java/com/flab/tabling/global/config/LogConfig.java
@@ -1,0 +1,15 @@
+package com.flab.tabling.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.flab.tabling.global.log.MdcLoggingFilter;
+
+@Configuration
+public class LogConfig {
+
+	@Bean
+	public MdcLoggingFilter mdcLoggingFilter() {
+		return new MdcLoggingFilter();
+	}
+}

--- a/src/main/java/com/flab/tabling/global/log/MdcLoggingFilter.java
+++ b/src/main/java/com/flab/tabling/global/log/MdcLoggingFilter.java
@@ -1,0 +1,29 @@
+package com.flab.tabling.global.log;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MdcLoggingFilter implements Filter {
+
+	private final String REQUEST_ID = "request_id";
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
+		IOException,
+		ServletException {
+		MDC.put(REQUEST_ID, String.valueOf(UUID.randomUUID()));
+		chain.doFilter(request, response);
+		MDC.clear();
+	}
+}

--- a/src/main/java/com/flab/tabling/global/log/MdcLoggingFilter.java
+++ b/src/main/java/com/flab/tabling/global/log/MdcLoggingFilter.java
@@ -13,10 +13,13 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 
+/*
+@Order: 등록된 필터의 적용 순서 설정
+ */
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class MdcLoggingFilter implements Filter {
 
-	private final String REQUEST_ID = "request_id";
+	private static final String REQUEST_ID = "request_id";
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,9 +6,9 @@
     <include resource="file-appender.xml"/>
 
     <property name="CONSOLE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %clr(%5level) %clr([%t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} - %msg%n"/>
+              value="[%X{request_id:-start-up}] %d{yyyy-MM-dd HH:mm:ss.SSS} %clr(%5level) %clr([%t]){faint} %clr(%logger){cyan} %clr(:){faint} - %msg%n"/>
     <property name="FILE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5level ${PID:- } -&#45;&#45; [%15.15t] %-40.40logger{39} : %msg%n"/>
+              value="[%X{request_id:-start-up}] %d{yyyy-MM-dd HH:mm:ss.SSS} %5level ${PID:- } -&#45;&#45; [%t] %logger : %msg%n"/>
     <property name="LOG_PATH" value="./logs"/>
 
     <!--local-->


### PR DESCRIPTION
## 작업 사항

* 로거 및 스레드 이름을 축약하지 않도록 길이 제한 제거
* MDC 패턴을 적용해서 요청별 UUID 추가
* MDC 로깅 필터는 테스트 커버리지 대상에서 제외

## Self-Check

- [x] 메서드 깊이는 2단계를 유지했습니다.
- [x] else 키워드를 사용하지 않았습니다.
- [x] setter/property를 사용하지 않았습니다.
- [x] 과도하게 줄여쓰지 않았습니다.
