### PR TITLE
[#70] MemberFacade와 AuthFacade가 추상화에 의존하도록 수정

### DIFF
--- a/src/main/java/com/flab/tabling/member/facade/AuthFacade.java
+++ b/src/main/java/com/flab/tabling/member/facade/AuthFacade.java
@@ -5,9 +5,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.flab.tabling.global.constant.SessionConstant;
 import com.flab.tabling.global.exception.ErrorCode;
-import com.flab.tabling.global.service.OneWayCipherService;
+import com.flab.tabling.global.service.CipherService;
 import com.flab.tabling.global.service.SessionService;
-import com.flab.tabling.global.service.TwoWayCipherService;
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.member.dto.MemberAuthDto;
 import com.flab.tabling.member.exception.InvalidPasswordException;
@@ -19,10 +18,10 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class AuthFacade {
-	private final TwoWayCipherService twoWayCipherService;
-	private final OneWayCipherService oneWayCipherService;
-	private final SessionService sessionService;
+	private final CipherService oneWayCipherService;
+	private final CipherService twoWayCipherService;
 	private final MemberQueryService memberQueryService;
+	private final SessionService sessionService;
 
 	@Transactional(readOnly = true)
 	public MemberAuthDto.Response login(MemberAuthDto.Request memberRequestDto, HttpSession session) {

--- a/src/main/java/com/flab/tabling/member/facade/MemberFacade.java
+++ b/src/main/java/com/flab/tabling/member/facade/MemberFacade.java
@@ -4,9 +4,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.flab.tabling.global.constant.SessionConstant;
-import com.flab.tabling.global.service.OneWayCipherService;
+import com.flab.tabling.global.service.CipherService;
 import com.flab.tabling.global.service.SessionService;
-import com.flab.tabling.global.service.TwoWayCipherService;
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.member.dto.MemberAddDto;
 import com.flab.tabling.member.service.MemberQueryService;
@@ -18,8 +17,8 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class MemberFacade {
-	private final OneWayCipherService oneWayCipherService;
-	private final TwoWayCipherService twoWayCipherService;
+	private final CipherService oneWayCipherService;
+	private final CipherService twoWayCipherService;
 	private final MemberService memberService;
 	private final MemberQueryService memberQueryService;
 	private final SessionService sessionService;

--- a/src/test/java/com/flab/tabling/member/facade/AuthFacadeTest.java
+++ b/src/test/java/com/flab/tabling/member/facade/AuthFacadeTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,7 +27,6 @@ import jakarta.servlet.http.HttpSession;
 
 @ExtendWith(MockitoExtension.class)
 class AuthFacadeTest {
-	@InjectMocks
 	AuthFacade authFacade;
 
 	@Mock
@@ -43,11 +41,12 @@ class AuthFacadeTest {
 	@Mock
 	MemberQueryService memberQueryService;
 
+	@Mock
 	HttpSession session;
 
 	@BeforeEach
 	void init() {
-		session = new MockHttpSession();
+		authFacade = new AuthFacade(oneWayCipherService, twoWayCipherService, memberQueryService, sessionService);
 	}
 
 	@Test

--- a/src/test/java/com/flab/tabling/member/facade/MemberFacadeTest.java
+++ b/src/test/java/com/flab/tabling/member/facade/MemberFacadeTest.java
@@ -4,10 +4,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,11 +27,11 @@ import com.flab.tabling.member.service.MemberService;
 
 @ExtendWith(MockitoExtension.class)
 class MemberFacadeTest {
-	@InjectMocks
 	MemberFacade memberFacade;
 
 	@Mock
 	OneWayCipherService oneWayCipherService;
+
 	@Mock
 	TwoWayCipherService twoWayCipherService;
 
@@ -46,6 +46,12 @@ class MemberFacadeTest {
 
 	@Mock
 	MockHttpSession session;
+
+	@BeforeEach
+	public void init() {
+		memberFacade = new MemberFacade(oneWayCipherService, twoWayCipherService, memberService, memberQueryService,
+			sessionService);
+	}
 
 	@Test
 	@DisplayName("회원가입 성공 : 이메일이 중복되지 않음")


### PR DESCRIPTION
## 작업 사항

* 각각 `OneWayCipherService`, `TwoWayCipherService` 대신 `CipherService`를 의존하도록 수정
  * 테스트 도중 Mock 객체가 제대로 주입되지 않는 문제 발생
  * `@InjectMocks`을 사용하지 않고, 직접 Mock 객체를 주입해서 해결
* 일관성을 위해 `AuthFacade` 필드 순서를 변경

## Self-Check

- [x] 메서드 깊이는 2단계를 유지했습니다.
- [x] else 키워드를 사용하지 않았습니다.
- [x] setter/property를 사용하지 않았습니다.
- [x] 과도하게 줄여쓰지 않았습니다.
