### PR TITLE
[#76] 식당 대기열 생성 과정에서 발생한 동시성 문제 해결

### DIFF
--- a/src/main/java/com/flab/tabling/waiting/domain/Waiting.java
+++ b/src/main/java/com/flab/tabling/waiting/domain/Waiting.java
@@ -44,11 +44,11 @@ public class Waiting extends BaseTime {
 	private WaitingStatus status;
 
 	@Builder
-	public Waiting(Store store, Member member, Integer headCount, WaitingStatus waitingStatus) {
+	public Waiting(Store store, Member member, Integer headCount, WaitingStatus status) {
 		this.store = store;
 		this.member = member;
 		this.headCount = headCount;
-		this.status = waitingStatus;
+		this.status = status;
 	}
 
 	@PrePersist

--- a/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
@@ -3,14 +3,13 @@ package com.flab.tabling.waiting.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.store.domain.Store;
 import com.flab.tabling.waiting.domain.Waiting;
 import com.flab.tabling.waiting.domain.WaitingStatus;
-
-import jakarta.persistence.LockModeType;
 
 /**
  * @Lock : 비관적 락, 낙관적 락과 관련하여 락 모드를 지정한다.
@@ -24,7 +23,7 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
 	Optional<Waiting> findFirstByStoreAndStatus(Store store, WaitingStatus status);
 
-	@Lock(LockModeType.PESSIMISTIC_READ)
-	Integer countWithPessimisticLockByStoreAndStatus(Store store, WaitingStatus status);
-
+	@Query(value = "select count(*) from waiting where store_id = :#{#store.id} and status = :#{#status.name} for update", nativeQuery = true)
+	Integer countWithPessimisticLockByStoreAndStatus(@Param("store") Store store,
+		@Param("status") WaitingStatus status);
 }

--- a/src/main/resources/h2/data.sql
+++ b/src/main/resources/h2/data.sql
@@ -8143,48 +8143,48 @@ VALUES (6, 2, 2, '2023-09-27', null, null, null);
 -- 웨이팅
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (1, 1, 4, 3, '2023-09-28', null, null, null, '1:1:2023-09-28');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (1, 1, 4, 3, 'ONGOING', '2023-09-28', null, null, null, '1:1:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (2, 1, 5, 4, '2023-09-28', null, null, null, '1:5:2023-09-28');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (2, 1, 5, 4, 'ONGOING', '2023-09-28', null, null, null, '1:5:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (3, 1, 6, 6, '2023-09-28', null, null, null, '1:6:2023-09-28');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (3, 1, 6, 6, 'ONGOING', '2023-09-28', null, null, null, '1:6:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (4, 2, 7, 2, '2023-09-28', null, null, null, '2:7:2023-09-28');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (4, 2, 7, 2, 'ONGOING', '2023-09-28', null, null, null, '2:7:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (5, 2, 8, 1, '2023-09-28', null, null, null, '2:8:2023-09-28');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (5, 2, 8, 1, 'ONGOING', '2023-09-28', null, null, null, '2:8:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (6, 3, 9, 4, '2023-09-28', null, null, null, '3:9:2023-09-28');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (6, 3, 9, 4, 'ONGOING', '2023-09-28', null, null, null, '3:9:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (7, 3, 10, 2, '2023-09-28', null, null, null, '3:10:2023-09-28');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (7, 3, 10, 2, 'ONGOING', '2023-09-28', null, null, null, '3:10:2023-09-28');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (8, 1, 7, 2, '2023-10-20 15:30:00', null, null, null, '1:7:2023-10-20');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (8, 1, 7, 2, 'ONGOING', '2023-10-20 15:30:00', null, null, null, '1:7:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (9, 3, 4, 2, '2023-10-20 15:30:00', null, null, null, '3:4:2023-10-20');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (9, 3, 4, 2, 'ONGOING', '2023-10-20 15:30:00', null, null, null, '3:4:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (10, 3, 5, 4, '2023-10-20 15:30:00', null, null, null, '3:5:2023-10-20');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (10, 3, 5, 4, 'ONGOING', '2023-10-20 15:30:00', null, null, null, '3:5:2023-10-20');
 INSERT
 INTO waiting
-(id, store_id, member_id, head_count, created_at, modified_at, created_by, modified_by, code)
-VALUES (11, 3, 6, 2, '2023-10-20 15:30:00', null, null, null, '3:6:2023-10-20');
+(id, store_id, member_id, head_count, status, created_at, modified_at, created_by, modified_by, code)
+VALUES (11, 3, 6, 2, 'ONGOING', '2023-10-20 15:30:00', null, null, null, '3:6:2023-10-20');
 
 -- 공지사항
 INSERT

--- a/src/test/java/com/flab/tabling/waiting/integrity/WaitingConcurrencyTest.java
+++ b/src/test/java/com/flab/tabling/waiting/integrity/WaitingConcurrencyTest.java
@@ -1,0 +1,85 @@
+package com.flab.tabling.waiting.integrity;
+
+import static com.flab.tabling.waiting.domain.WaitingStatus.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.tabling.global.audit.LoginMemberAuditorAware;
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.member.repository.MemberRepository;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.store.repository.StoreRepository;
+import com.flab.tabling.waiting.repository.WaitingRepository;
+import com.flab.tabling.waiting.service.WaitingService;
+
+import jakarta.persistence.EntityManager;
+
+/*
+@Commit: @Transactional 이 적용된 테스트 코드를 커밋할 수 있습니다.
+ */
+@SpringBootTest
+public class WaitingConcurrencyTest {
+	static final int WAITING_SAMPLE_DATA_SIZE = 11;
+	@Autowired
+	WaitingService waitingService;
+	@Autowired
+	WaitingRepository waitingRepository;
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	StoreRepository storeRepository;
+	@Autowired
+	EntityManager entityManager;
+	@MockBean
+	LoginMemberAuditorAware loginMemberAuditorAware;
+	int idx = 0;
+
+	@Test
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	@Commit
+	@DisplayName("다수의 사용자가 동시에 대기 요청해도 최대 대기 가능 인원수를 초과하지 않는다.")
+	void concurrencyTest() throws InterruptedException {
+		//given
+		Store store = storeRepository.findById(1L).get();
+		List<Member> members = getMembers();
+
+		//when
+		executeConcurrentRequests(store, members);
+		Thread.sleep(1000);
+		entityManager.flush();
+		entityManager.clear();
+
+		//then
+		int countAfterConcurrentRequests = waitingRepository.countWithPessimisticLockByStoreAndStatus(store, ONGOING);
+		assertThat(countAfterConcurrentRequests).isEqualTo(store.getMaxWaitingCount());
+		entityManager.createNativeQuery("delete from waiting where id > " + WAITING_SAMPLE_DATA_SIZE).executeUpdate();
+	}
+
+	private void executeConcurrentRequests(Store store, List<Member> members) {
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		for (int i = 0; i < 8; i++) {
+			executorService.execute(() -> waitingService.add(store, members.get(idx++), 3));
+		}
+	}
+
+	private List<Member> getMembers() {
+		List<Member> members = new ArrayList<>();
+		for (int i = 8; i < 16; i++) {
+			members.add(memberRepository.findById((long)i).get());
+		}
+		return members;
+	}
+}

--- a/src/test/java/com/flab/tabling/waiting/integrity/WaitingDuplicatedTest.java
+++ b/src/test/java/com/flab/tabling/waiting/integrity/WaitingDuplicatedTest.java
@@ -1,0 +1,50 @@
+package com.flab.tabling.waiting.integrity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.tabling.global.audit.LoginMemberAuditorAware;
+import com.flab.tabling.member.domain.Member;
+import com.flab.tabling.member.repository.MemberRepository;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.store.repository.StoreRepository;
+import com.flab.tabling.waiting.exception.WaitingDuplicatedException;
+import com.flab.tabling.waiting.repository.WaitingRepository;
+import com.flab.tabling.waiting.service.WaitingService;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+public class WaitingDuplicatedTest {
+	@Autowired
+	WaitingService waitingService;
+	@Autowired
+	WaitingRepository waitingRepository;
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	StoreRepository storeRepository;
+	@Autowired
+	EntityManager entityManager;
+	@MockBean
+	LoginMemberAuditorAware loginMemberAuditorAware;
+
+	@Test
+	@Transactional
+	@DisplayName("하나의 식당에 동일한 회원이 중복 요청할 경우 WaitingDuplicatedException 가 발생한다.")
+	public void failSaveByDuplicatedMember() {
+		//given
+		Member member = memberRepository.findById(2L).get();
+		Store store = storeRepository.findById(1L).get();
+
+		//expected
+		waitingService.add(store, member, 3);
+		assertThrows(WaitingDuplicatedException.class, () -> waitingService.add(store, member, 3));
+	}
+}

--- a/src/test/java/com/flab/tabling/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/flab/tabling/waiting/service/WaitingServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.store.domain.Store;
@@ -54,7 +53,7 @@ class WaitingServiceTest {
 	}
 
 	@Test
-	@DisplayName("대기열 멤버 추가 실패 : 동일 데이터 생성 시")
+	@DisplayName("대기열 멤버 추가 실패 : 동일한 사용자가 하나의 식당에 중복 요청할 경우")
 	void failAddMemberBySameWaiting() {
 		//given
 		Member member = WaitingFixture.getMember();
@@ -63,21 +62,6 @@ class WaitingServiceTest {
 		Waiting waiting = WaitingFixture.getWaiting(store, member);
 		doReturn(Optional.of(waiting)).when(waitingRepository)
 			.findByMemberAndStoreAndStatus(member, store, WaitingStatus.ONGOING);
-		// //when
-		assertThrows(WaitingDuplicatedException.class, () -> waitingService.add(store, member, waiting.getHeadCount()));
-	}
-
-	@Test
-	@DisplayName("대기열 멤버 추가 실패 : 유니크 키가 같은 데이터 생성 시")
-	void failAddMemberBySameUniqueKey() {
-		//given
-		Member member = WaitingFixture.getMember();
-		Member seller = WaitingFixture.getMember();
-		Store store = WaitingFixture.getStore(seller);
-		Waiting waiting = WaitingFixture.getWaiting(store, member);
-		doReturn(Optional.empty()).when(waitingRepository)
-			.findByMemberAndStoreAndStatus(member, store, WaitingStatus.ONGOING);
-		doThrow(DataIntegrityViolationException.class).when(waitingRepository).save(any(Waiting.class));
 		//when
 		assertThrows(WaitingDuplicatedException.class, () -> waitingService.add(store, member, waiting.getHeadCount()));
 	}
@@ -177,7 +161,7 @@ class WaitingServiceTest {
 	}
 
 	@Test
-	@DisplayName("가게의 대기열 첫번째 멤버 입장 성공")
+	@DisplayName("대기열이 존재하지 않는 경우, 가게의 허가 요청 실패")
 	void failAcceptFirstOfStore() {
 		//given
 		Member seller = WaitingFixture.getMember();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost/tabling?serverTimezone=UTC
+    driverClassName: com.mysql.cj.jdbc.Driver
+    username: root
+    password: qwer1234!
+  jpa:
+    show-sql: true
+tabling:
+  security-credentials:
+    login-path: "/login"
+    login-method: "POST"
+    member-add-path: "/members"
+    member-add-method: "POST"
+    bytes-encryptor-password: "This is a password!"
+    bytes-encryptor-salt: "0123456f"


### PR DESCRIPTION
## 작업 사항

* 네이티브 쿼리와 X Lock을 사용해 동시성 문제를 해결했습니다.
* `WaitingService`의 `waitingRepository.save(waiting);`에 있는 예외 처리 및 테스트 코드 제거
  * X Lock을 사용하기 때문에 해당 지점까지 도달하지 못합니다.
  * 모든 대기 요청의 중복 검사는 `checkDuplicatedWaiting(store, member);`에서 처리됩니다.
* 동시성 문제 및 데이터 중복 문제에 대한 테스트 코드 추가
* `Waiting` 클래스의 필드 명(status)과 일치하도록 생성자의 매개 변수명을 수정했습니다.
* `data.sql`의 웨이팅 샘플 데이터에 `status` 컬럼이 누락되어 있어 추가했습니다.

### 네이티브 쿼리를 사용한 이유
`@Lock(LockModeType.PESSIMISTIC_READ)`를 사용했지만, 아래 로그와 함께 실제 데이터베이스에는 락이 잡히지 않았습니다.
```
org.hibernate.sql.results.jdbc.internal.DeferredResultSetAccess - Encountered request for locking however dialect reports that database prefers locking be done in a separate select (follow-on locking); results will be locked after initial query executes
```
메서드 네임 쿼리 대신 `@Query`를 활용해 보았지만, 결과는 동일했습니다.
락이 잡히지 않으면 다음과 같은 문제가 발생합니다.

#### 기존 시나리오
식당의 최대 대기 가능 인원은 5명이라 가정했습니다.
![db 테스트 데드락 발생](https://github.com/f-lab-edu/tabling/assets/118912510/5a9d145d-7976-4581-b3ca-bdc65ec5ebda)
4번 과정에서 데드락이 발생하고 TransactionB가 롤백되기 때문에 대기 인원이 5명을 초과하지 않습니다.
재시도를 통해 다시 한번 검증 과정을 거치기 때문입니다.(9번 과정)

#### 락이 잡히지 않았을 때의 시나리오
아래와 같이 동시에 검증을 통과한 후, 재시도 없이 쓰기 작업을 수행합니다.
![db 테스트 동시성 문제 발생](https://github.com/f-lab-edu/tabling/assets/118912510/3629598e-437d-4f13-a7fd-af25eb54b709)

이 때문에 비즈니스 수준의 정합성을 지킬 수 없게 되며, 실제로 락을 잡기 위해 네이티브 쿼리를 사용했습니다.

### X Lock을 사용한 이유
기존의 S Lock 방식은 데드락 발생으로 인해, 동시성 문제를 원할하게 처리할 수 없었습니다.
재시도 로직을 활용해 보았지만, 요청이 몰리게 되면 충돌로 인해 대부분의 요청이 실패 처리 되었습니다.
결국 순차적으로 처리해야 된다고 판단했고, X Lock을 사용하게 되었습니다.

### 추후 해결이 필요한 부분
* `@Lock(LockModeType.PESSIMISTIC_READ)`을 사용했을 때, 실제 데이터베이스에 락을 잡지 않는 이유를 아직 명확하게 파악하지 못했습니다.
* X Lock을 사용했기 때문에 성능 측면에서 부정적인 영향을 미칠 수 있습니다.
  * `Queue`나 `Redis`를 활용해 보는 것도 좋을 것 같습니다.



## Self-Check

- [x] 메서드 깊이는 2단계를 유지했습니다.
- [x] else 키워드를 사용하지 않았습니다.
- [x] setter/property를 사용하지 않았습니다.
- [x] 과도하게 줄여쓰지 않았습니다.
