### PR TITLE
[#78] Named lock을 활용해 식당 대기 시스템의 동시성 문제 해결

### DIFF
--- a/.github/workflows/ci-with-api-docs.yml
+++ b/.github/workflows/ci-with-api-docs.yml
@@ -18,16 +18,28 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Set up MySQL
+        uses: samin/mysql-action@v1.3
+        with:
+          host port: 3306
+          container port: 3306
+          mysql database: 'tabling'
+          mysql user: 'developer'
+          mysql password: '1111'
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
       - name: auto configure spring rest docs
         run: |
           ./gradlew build -x test
           ./gradlew copyDocument
+
       - name: upload pages artifact
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'src/main/resources/static/docs'
+
   deploy:
     needs: build
     permissions:

--- a/.github/workflows/ci-with-gradle.yml
+++ b/.github/workflows/ci-with-gradle.yml
@@ -27,13 +27,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - uses: mirromutth/mysql-action@v1.1
+      - name: Set up MySQL
+        uses: samin/mysql-action@v1.3
         with:
           host port: 3306
           container port: 3306
           mysql database: 'tabling'
-          mysql user: 'root'
-          mysql password: 1111
+          mysql user: 'developer'
+          mysql password: '1111'
 
       - name: Grant execute permission for gradlew
         run : chmod +x gradlew

--- a/.github/workflows/ci-with-gradle.yml
+++ b/.github/workflows/ci-with-gradle.yml
@@ -27,6 +27,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - uses: mirromutth/mysql-action@v1.1
+        with:
+          host port: 3306
+          container port: 3306
+          mysql database: 'tabling'
+          mysql user: 'root'
+          mysql password: 1111
+
       - name: Grant execute permission for gradlew
         run : chmod +x gradlew
 

--- a/.github/workflows/ci-with-test-coverage.yml
+++ b/.github/workflows/ci-with-test-coverage.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Build without test
         run: ./gradlew build -x test
 
+      - name: Set up MySQL
+        uses: samin/mysql-action@v1.3
+        with:
+          host port: 3306
+          container port: 3306
+          mysql database: 'tabling'
+          mysql user: 'developer'
+          mysql password: '1111'
+
       - name : auto configure spring rest docs
         run: |
           ./gradlew copyDocument

--- a/build.gradle
+++ b/build.gradle
@@ -32,23 +32,42 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // bcrypt
     implementation 'org.springframework.security:spring-security-crypto'
+
+    // monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
-    compileOnly 'org.projectlombok:lombok'
+
+    // database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
+
+    // custom property
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    // easy-random: 랜덤 테스트 데이터 생성 라이브러리
-    testImplementation 'org.jeasy:easy-random-core:5.0.0'
+
+    // lombok
+    annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     //rest-docs
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // easy-random: 랜덤 테스트 데이터 생성 라이브러리
+    testImplementation 'org.jeasy:easy-random-core:5.0.0'
 }
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/flab/tabling/global/repository/NamedLockRepository.java
+++ b/src/main/java/com/flab/tabling/global/repository/NamedLockRepository.java
@@ -1,0 +1,21 @@
+package com.flab.tabling.global.repository;
+
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class NamedLockRepository {
+
+	private final EntityManager entityManager;
+
+	public void getLock(String key) {
+		entityManager.createNativeQuery("select get_lock(:key, 3000)").setParameter("key", key).getSingleResult();
+	}
+
+	public void releaseLock(String key) {
+		entityManager.createNativeQuery("select release_lock(:key)").setParameter("key", key).getSingleResult();
+	}
+}

--- a/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/flab/tabling/waiting/repository/WaitingRepository.java
@@ -3,14 +3,11 @@ package com.flab.tabling.waiting.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.store.domain.Store;
 import com.flab.tabling.waiting.domain.Waiting;
 import com.flab.tabling.waiting.domain.WaitingStatus;
-
-import jakarta.persistence.LockModeType;
 
 /**
  * @Lock : 비관적 락, 낙관적 락과 관련하여 락 모드를 지정한다.
@@ -24,7 +21,5 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
 	Optional<Waiting> findFirstByStoreAndStatus(Store store, WaitingStatus status);
 
-	@Lock(LockModeType.PESSIMISTIC_READ)
-	Integer countWithPessimisticLockByStoreAndStatus(Store store, WaitingStatus status);
-
+	Integer countByStoreAndStatus(Store store, WaitingStatus status);
 }

--- a/src/test/java/com/flab/tabling/waiting/facade/WaitingFacadeTest.java
+++ b/src/test/java/com/flab/tabling/waiting/facade/WaitingFacadeTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.flab.tabling.global.exception.AuthorizationException;
+import com.flab.tabling.global.repository.NamedLockRepository;
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.member.service.MemberQueryService;
 import com.flab.tabling.store.domain.Store;
@@ -35,6 +36,8 @@ class WaitingFacadeTest {
 	MemberQueryService memberQueryService;
 	@Mock
 	WaitingService waitingService;
+	@Mock
+	NamedLockRepository namedLockRepository;
 
 	@Test
 	@DisplayName("사용자 식당 대기열 추가 성공")

--- a/src/test/java/com/flab/tabling/waiting/integrity/WaitingFacadeConcurrencyTest.java
+++ b/src/test/java/com/flab/tabling/waiting/integrity/WaitingFacadeConcurrencyTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.annotation.Commit;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,13 +23,12 @@ import com.flab.tabling.waiting.repository.WaitingRepository;
 import com.flab.tabling.waiting.service.WaitingService;
 
 import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
 
-/*
-@Commit: @Transactional 이 적용된 테스트 코드를 커밋할 수 있습니다.
- */
+@Slf4j
 @SpringBootTest
 public class WaitingFacadeConcurrencyTest {
-	static final int WAITING_SAMPLE_DATA_SIZE = 11;
+
 	@Autowired
 	WaitingService waitingService;
 	@Autowired
@@ -45,32 +43,29 @@ public class WaitingFacadeConcurrencyTest {
 	EntityManager entityManager;
 	@MockBean
 	LoginMemberAuditorAware loginMemberAuditorAware;
-	Long idx = 8L;
+	private Long memberIdx = 2L;
 
 	@Test
-	@Transactional(isolation = Isolation.READ_COMMITTED)
-	@Commit
+	@Transactional(isolation = Isolation.READ_UNCOMMITTED)
 	@DisplayName("다수의 사용자가 동시에 대기 요청해도 최대 대기 가능 인원수를 초과하지 않는다.")
 	void concurrencyTest() throws InterruptedException {
 		//given
 		Store store = storeRepository.findById(1L).get();
 
 		//when
-		executeConcurrentRequests();
-		Thread.sleep(1000);
-		entityManager.flush();
-		entityManager.clear();
+		executeConcurrentRequests(store.getId());
 
 		//then
 		int countAfterConcurrentRequests = waitingRepository.countByStoreAndStatus(store, ONGOING);
 		assertThat(countAfterConcurrentRequests).isEqualTo(store.getMaxWaitingCount());
-		entityManager.createNativeQuery("delete from waiting where id > " + WAITING_SAMPLE_DATA_SIZE).executeUpdate();
+		entityManager.createNativeQuery("delete from waiting where id > " + 1L).executeUpdate();
 	}
 
-	private void executeConcurrentRequests() {
+	private void executeConcurrentRequests(Long storeId) throws InterruptedException {
 		ExecutorService executorService = Executors.newFixedThreadPool(10);
 		for (int i = 0; i < 8; i++) {
-			executorService.execute(() -> waitingFacade.add(1L, idx++, 3));
+			executorService.execute(() -> waitingFacade.add(storeId, memberIdx++, 3));
 		}
+		Thread.sleep(1000);
 	}
 }

--- a/src/test/java/com/flab/tabling/waiting/integrity/WaitingFacadeConcurrencyTest.java
+++ b/src/test/java/com/flab/tabling/waiting/integrity/WaitingFacadeConcurrencyTest.java
@@ -1,0 +1,76 @@
+package com.flab.tabling.waiting.integrity;
+
+import static com.flab.tabling.waiting.domain.WaitingStatus.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.tabling.global.audit.LoginMemberAuditorAware;
+import com.flab.tabling.member.repository.MemberRepository;
+import com.flab.tabling.store.domain.Store;
+import com.flab.tabling.store.repository.StoreRepository;
+import com.flab.tabling.waiting.facade.WaitingFacade;
+import com.flab.tabling.waiting.repository.WaitingRepository;
+import com.flab.tabling.waiting.service.WaitingService;
+
+import jakarta.persistence.EntityManager;
+
+/*
+@Commit: @Transactional 이 적용된 테스트 코드를 커밋할 수 있습니다.
+ */
+@SpringBootTest
+public class WaitingFacadeConcurrencyTest {
+	static final int WAITING_SAMPLE_DATA_SIZE = 11;
+	@Autowired
+	WaitingService waitingService;
+	@Autowired
+	WaitingFacade waitingFacade;
+	@Autowired
+	WaitingRepository waitingRepository;
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	StoreRepository storeRepository;
+	@Autowired
+	EntityManager entityManager;
+	@MockBean
+	LoginMemberAuditorAware loginMemberAuditorAware;
+	Long idx = 8L;
+
+	@Test
+	@Transactional(isolation = Isolation.READ_COMMITTED)
+	@Commit
+	@DisplayName("다수의 사용자가 동시에 대기 요청해도 최대 대기 가능 인원수를 초과하지 않는다.")
+	void concurrencyTest() throws InterruptedException {
+		//given
+		Store store = storeRepository.findById(1L).get();
+
+		//when
+		executeConcurrentRequests();
+		Thread.sleep(1000);
+		entityManager.flush();
+		entityManager.clear();
+
+		//then
+		int countAfterConcurrentRequests = waitingRepository.countByStoreAndStatus(store, ONGOING);
+		assertThat(countAfterConcurrentRequests).isEqualTo(store.getMaxWaitingCount());
+		entityManager.createNativeQuery("delete from waiting where id > " + WAITING_SAMPLE_DATA_SIZE).executeUpdate();
+	}
+
+	private void executeConcurrentRequests() {
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		for (int i = 0; i < 8; i++) {
+			executorService.execute(() -> waitingFacade.add(1L, idx++, 3));
+		}
+	}
+}

--- a/src/test/java/com/flab/tabling/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/flab/tabling/waiting/service/WaitingServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 
 import com.flab.tabling.member.domain.Member;
 import com.flab.tabling.store.domain.Store;
@@ -64,21 +63,6 @@ class WaitingServiceTest {
 		doReturn(Optional.of(waiting)).when(waitingRepository)
 			.findByMemberAndStoreAndStatus(member, store, WaitingStatus.ONGOING);
 		// //when
-		assertThrows(WaitingDuplicatedException.class, () -> waitingService.add(store, member, waiting.getHeadCount()));
-	}
-
-	@Test
-	@DisplayName("대기열 멤버 추가 실패 : 유니크 키가 같은 데이터 생성 시")
-	void failAddMemberBySameUniqueKey() {
-		//given
-		Member member = WaitingFixture.getMember();
-		Member seller = WaitingFixture.getMember();
-		Store store = WaitingFixture.getStore(seller);
-		Waiting waiting = WaitingFixture.getWaiting(store, member);
-		doReturn(Optional.empty()).when(waitingRepository)
-			.findByMemberAndStoreAndStatus(member, store, WaitingStatus.ONGOING);
-		doThrow(DataIntegrityViolationException.class).when(waitingRepository).save(any(Waiting.class));
-		//when
 		assertThrows(WaitingDuplicatedException.class, () -> waitingService.add(store, member, waiting.getHeadCount()));
 	}
 

--- a/src/test/java/com/flab/tabling/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/flab/tabling/waiting/service/WaitingServiceTest.java
@@ -91,7 +91,7 @@ class WaitingServiceTest {
 		Store store = WaitingFixture.getStore(seller);
 		Waiting waiting = WaitingFixture.getWaiting(store, member);
 		doReturn(store.getMaxWaitingCount() + 10).when(waitingRepository)
-			.countWithPessimisticLockByStoreAndStatus(store, WaitingStatus.ONGOING);
+			.countByStoreAndStatus(store, WaitingStatus.ONGOING);
 		//when, then
 		assertThrows(WaitingExceededException.class, () -> waitingService.add(store, member, waiting.getHeadCount()));
 	}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost/tabling?serverTimezone=UTC
+    url: jdbc:mysql://localhost:3306/tabling?serverTimezone=UTC
     driverClassName: com.mysql.cj.jdbc.Driver
-    username: root
+    username: developer
     password: 1111
   jpa:
     hibernate:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,9 +3,20 @@ spring:
     url: jdbc:mysql://localhost/tabling?serverTimezone=UTC
     driverClassName: com.mysql.cj.jdbc.Driver
     username: root
-    password: qwer1234!
+    password: 1111
   jpa:
-    show-sql: true
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql
+      data-locations: classpath:data.sql
+
 tabling:
   security-credentials:
     login-path: "/login"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost/tabling?serverTimezone=UTC
+    driverClassName: com.mysql.cj.jdbc.Driver
+    username: root
+    password: qwer1234!
+  jpa:
+    show-sql: true
+tabling:
+  security-credentials:
+    login-path: "/login"
+    login-method: "POST"
+    member-add-path: "/members"
+    member-add-method: "POST"
+    bytes-encryptor-password: "This is a password!"
+    bytes-encryptor-salt: "0123456f"

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,21 @@
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (1, 'member1', 'member1@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (2, 'member2', 'member2@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (3, 'member3', 'member3@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (4, 'member4', 'member4@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (5, 'member5', 'member5@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (6, 'member6', 'member6@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (7, 'member7', 'member7@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (8, 'member8', 'member8@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+insert into member(id, name, email, password, role_type, created_at, modified_at, created_by, modified_by)
+values (9, 'member9', 'member9@test.com', 'encrypted_password', 'CUSTOMER', '2024-08-27', null, null, null);
+
+insert into store(id, name, member_id, category, max_waiting_count, description, created_at, modified_at, created_by, modified_by)
+values (1, 'storeA', 1, 'SNACK_FOOD', 5, 'description', '2024-08-27', null, null, null);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,147 @@
+-- 참조 테이블들부터 삭제합니다.
+DROP TABLE IF EXISTS `history`;
+DROP TABLE IF EXISTS `favorite`;
+DROP TABLE IF EXISTS `waiting`;
+DROP TABLE IF EXISTS `menu`;
+DROP TABLE IF EXISTS `business_hour`;
+DROP TABLE IF EXISTS `notice`;
+DROP TABLE IF EXISTS `penalty`;
+DROP TABLE IF EXISTS `point`;
+DROP TABLE IF EXISTS `address`;
+
+-- 참조되는 테이블들을 삭제합니다.
+DROP TABLE IF EXISTS `store`;
+DROP TABLE IF EXISTS `member`;
+
+CREATE TABLE `member`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `name`        varchar(30)  NOT NULL,
+    `email`       varchar(255) NOT NULL COMMENT '암호화해서 저장',
+    `password`    varchar(255) NOT NULL COMMENT '암호화해서 저장',
+    `role_type`   varchar(20)  NOT NULL,
+    `created_at`  datetime(6)  NOT NULL,
+    `modified_at` datetime(6),
+    `created_by`  varchar(50),
+    `modified_by` varchar(50)
+);
+
+CREATE TABLE `store`
+(
+    `id`                bigint PRIMARY KEY AUTO_INCREMENT,
+    `member_id`         bigint      NOT NULL,
+    `category`          varchar(20) NOT NULL,
+    `name`              varchar(30) NOT NULL,
+    `description`       TEXT,
+    `max_waiting_count` integer COMMENT '대기할 수 있는 최대 사람 수',
+    `created_at`        datetime(6),
+    `modified_at`       datetime(6),
+    `created_by`        varchar(50),
+    `modified_by`       varchar(50)
+);
+
+CREATE TABLE `business_hour`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `store_id`    integer,
+    `day_of_week` varchar(10),
+    `start_time`  time(6),
+    `end_time`    time(6),
+    `created_at`  datetime(6),
+    `modified_at` datetime(6),
+    `created_by`  varchar(50),
+    `modified_by` varchar(50)
+);
+
+CREATE TABLE `menu`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `store_id`    bigint      NOT NULL,
+    `name`        varchar(20) NOT NULL COMMENT '메뉴 이름',
+    `description` TEXT,
+    `price`       integer     NOT NULL COMMENT '메뉴 가격',
+    `created_at`  datetime(6),
+    `modified_at` datetime(6),
+    `created_by`  varchar(50),
+    `modified_by` varchar(50)
+);
+
+CREATE TABLE `waiting`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `store_id`    bigint  NOT NULL,
+    `member_id`   bigint  NOT NULL,
+    `head_count`  integer NOT NULL COMMENT '예약하는 인원 수',
+    `status`      varchar(20),
+    `code`  varchar(50) NOT NULL COMMENT '{store_id}:{member_id}:{created_at}',
+    `created_at`  datetime(6),
+    `modified_at` datetime(6),
+    `created_by`  varchar(50),
+    `modified_by` varchar(50),
+    unique(code)
+);
+
+CREATE TABLE `notice`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `member_id`   bigint      NOT NULL,
+    `title`       varchar(50) NOT NULL,
+    `content`     text        NOT NULL,
+    `is_deleted`  tinyint COMMENT '논리적 삭제',
+    `created_at`  datetime(6) NOT NULL,
+    `modified_at` datetime(6),
+    `created_by`  varchar(50),
+    `modified_by` varchar(50)
+);
+
+CREATE TABLE `penalty`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `member_id`   bigint      NOT NULL,
+    `type`        varchar(20),
+    `created_at`  datetime(6) NOT NULL,
+    `modified_at` datetime(6),
+    `created_by`  varchar(50),
+    `modified_by` varchar(50)
+);
+
+CREATE TABLE `point`
+(
+    `id`          bigint PRIMARY KEY AUTO_INCREMENT,
+    `member_id`   bigint      NOT NULL,
+    `amount`      integer     NOT NULL,
+    `type`        varchar(20) NOT NULL,
+    `created_at`  datetime(6) NOT NULL,
+    `modified_at` datetime(6),
+    `created_by`  varchar(50),
+    `modified_by` varchar(50)
+);
+
+CREATE TABLE `address`
+(
+    `id`           bigint PRIMARY KEY AUTO_INCREMENT,
+    `store_id`     bigint,
+    `area1`        varchar(20) COMMENT '시도',
+    `area2`        varchar(20) COMMENT '시군구',
+    `area3`        varchar(20) COMMENT '읍면',
+    `land_name`    varchar(80) COMMENT '도로명',
+    `land_number1` integer COMMENT '지번본번',
+    `land_number2` integer COMMENT '지번부번',
+    `created_at`   datetime(6),
+    `modified_at`  datetime(6),
+    `created_by`   varchar(50),
+    `modified_by`  varchar(50)
+);
+
+CREATE TABLE `history`
+(
+    `id`             bigint PRIMARY KEY AUTO_INCREMENT,
+    `table_name`     varchar(30),
+    `record_id`      bigint,
+    `operation_type` varchar(20) COMMENT '상태값',
+    `snapshot`       json,
+    `created_at`     datetime(6),
+    `modified_at`    datetime(6),
+    `created_by`     varchar(50),
+    `modified_by`    varchar(50)
+);


### PR DESCRIPTION
## 작업 사항

### 별도의 큐를 구현하지 않고 Named Lock을 활용해서 동시성 문제를 해결했습니다.
  * 비관적 락(X lock)을 사용하면 모든 요청을 순차적으로 처리합니다.
<img src = "https://github.com/user-attachments/assets/e1f1dd5e-1717-48d0-8011-bf93e60f6632" width="60%" height="60%">

  * **Named Lock을 활용해 식당 단위로 순차 처리**되도록 구현했습니다.
<img src = "https://github.com/user-attachments/assets/c5bda3a7-09d1-44b8-ba9a-38aea52734ca" width="60%" height="60%">

### WaitingService 클래스의 add() 메서드의 트랜잭션 전파 속성을 REQUIRES_NEW로 변경했습니다.
  * Named Lock이 해제되기 전, 생성된 데이터를 DB에 커밋하기 위해 전이 수준을 변경했습니다.
### 관련 테스트를 추가 및 수정했습니다.
  * mysql을 사용해 통합 테스트를 진행했습니다.
  * **테스트를 수행하기 전**, `username: developer`, `password: 1111` 로 **mysql의 초기 설정이 필요**합니다.
### ci 워크플로우를 수정했습니다.
  * 동시성 테스트 추가로 인해 ci 과정에서 mysql이 필요하게 되었습니다.
  * 이를 위해 mysql을 설치하고, 관련 설정을 추가해주는 action을 사용했습니다.

## Self-Check

- [x] 메서드 깊이는 2단계를 유지했습니다.
- [x] else 키워드를 사용하지 않았습니다.
- [x] setter/property를 사용하지 않았습니다.
- [x] 과도하게 줄여쓰지 않았습니다.
