### PR TITLE
Autofix: [Bug] 식당 대기 시스템의 동시성 문제

### DIFF
--- a/src/main/java/com/flab/tabling/global/service/NamedLockService.java
+++ b/src/main/java/com/flab/tabling/global/service/NamedLockService.java
@@ -1,8 +1,7 @@
 package com.flab.tabling.global.service;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 
 import org.springframework.stereotype.Component;
 
@@ -11,33 +10,26 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 public class NamedLockService {
-	private final ConcurrentHashMap<String, ReentrantLock> lockMap = new ConcurrentHashMap<>();
+	private final RedisTemplate<String, String> redisTemplate;
+	private final RedisScript<Boolean> lockScript;
+	private final RedisScript<Long> unlockScript;
 
-	private ReentrantLock getLock(String key) {
-		lockMap.putIfAbsent(key, new ReentrantLock(true));
-		return lockMap.get(key);
+	public NamedLockService(RedisTemplate<String, String> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+		this.lockScript = RedisScript.of("return redis.call('set', KEYS[1], ARGV[1], 'NX', 'PX', ARGV[2])", Boolean.class);
+		this.unlockScript = RedisScript.of("if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end", Long.class);
 	}
 
+
+	public boolean lock(String key, long timeout, TimeUnit unit) {
+		String lockValue = Thread.currentThread().getId() + ":";
+		long timeoutMillis = unit.toMillis(timeout);
+		return Boolean.TRUE.equals(redisTemplate.execute(lockScript, java.util.Collections.singletonList(key), lockValue, Long.toString(timeoutMillis)));
 	public void lock(String key, long timeout, TimeUnit unit) {
-		ReentrantLock lock = getLock(key);
-		try {
-			if (!lock.tryLock(timeout, unit)) {
-				throw new RuntimeException(
-					"Failed to acquire lock for key: " + key + " within timeout: " + timeout + " " + unit);
-			}
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt(); // 현재 스레드의 인터럽트 상태 복원
-			throw new RuntimeException("Thread was interrupted while trying to acquire lock for key: " + key, e);
-		}
-	}
 
 	public void unlock(String key) {
-		ReentrantLock lock = getLock(key);
-		if (lock.isHeldByCurrentThread()) {
-			lock.unlock();
-			if (!lock.hasQueuedThreads()) { // 현재 대기 중인 스레드가 있다면 제거하지 못한다.
-				lockMap.remove(key);
-			}
-		}
+		String lockValue = Thread.currentThread().getId() + ":";
+		redisTemplate.execute(unlockScript, java.util.Collections.singletonList(key), lockValue);
+	public void unlock(String key) {
 	}
 }

--- a/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
+++ b/src/main/java/com/flab/tabling/waiting/facade/WaitingFacade.java
@@ -61,8 +61,9 @@ public class WaitingFacade {
 	private Waiting addWaitingWithNamedLock(String lockKey, Store store, Member member, Integer headCount) {
 		Waiting waiting;
 		try {
+			if (!namedLockService.lock(lockKey, 3, SECONDS)) {
+				throw new RuntimeException("Failed to acquire lock for key: " + lockKey);
 			namedLockService.lock(lockKey, 3, SECONDS);
-			waiting = waitingService.add(store, member, headCount);
 		} finally {
 			namedLockService.unlock(lockKey);
 		}

--- a/src/test/java/com/flab/tabling/waiting/integrity/WaitingFacadeConcurrencyTest.java
+++ b/src/test/java/com/flab/tabling/waiting/integrity/WaitingFacadeConcurrencyTest.java
@@ -26,6 +26,7 @@ import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@TestPropertySource(properties = {"spring.data.redis.host=localhost", "spring.data.redis.port=6379"})
 @SpringBootTest
 public class WaitingFacadeConcurrencyTest {
 
@@ -62,7 +63,10 @@ public class WaitingFacadeConcurrencyTest {
 	}
 
 	private void executeConcurrentRequests(Long storeId) throws InterruptedException {
+		int threadCount = 20;
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
 		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		for (int i = 0; i < threadCount; i++) {
 		for (int i = 0; i < 8; i++) {
 			executorService.execute(() -> waitingFacade.add(storeId, memberIdx++, 3));
 		}


### PR DESCRIPTION
Replace in-memory NamedLockService with Redis-based distributed locking to handle concurrency in scale-out situations. This involves modifying NamedLockService to use Redis, updating WaitingFacade to use the new locking mechanism, and adjusting the test case. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    